### PR TITLE
callable is no longer considered to be "atomic"

### DIFF
--- a/doc/grammars/type.abnf
+++ b/doc/grammars/type.abnf
@@ -14,7 +14,8 @@ Intersection
 	= 1*(TokenIntersection Atomic)
 
 Nullable
-	= TokenNullable TokenIdentifier [Generic]
+	= TokenNullable Callable
+	/ TokenNullable TokenIdentifier [Generic]
 
 Atomic
 	= TokenIdentifier [Generic / Array]
@@ -46,8 +47,7 @@ CallableParameterIsOptional
 	= TokenEqualSign
 
 CallableReturnType
-	= TokenIdentifier [Generic]
-	/ Nullable
+	= [TokenNullable] TokenIdentifier [Generic]
 	/ TokenParenthesesOpen Type TokenParenthesesClose
 
 Array

--- a/doc/grammars/type.abnf
+++ b/doc/grammars/type.abnf
@@ -3,8 +3,9 @@
 ; ---------------------------------------------------------------------------- ;
 
 Type
-	= Atomic [Union / Intersection]
+	= Callable
 	/ Nullable
+	/ Atomic [Union / Intersection]
 
 Union
 	= 1*(TokenUnion Atomic)
@@ -16,7 +17,7 @@ Nullable
 	= TokenNullable TokenIdentifier [Generic]
 
 Atomic
-	= TokenIdentifier [Generic / Callable / Array]
+	= TokenIdentifier [Generic / Array]
 	/ TokenThisVariable
 	/ TokenParenthesesOpen Type TokenParenthesesClose [Array]
 
@@ -24,7 +25,7 @@ Generic
 	= TokenAngleBracketOpen Type *(TokenComma Type) TokenAngleBracketClose
 
 Callable
-	= TokenParenthesesOpen [CallableParameters] TokenParenthesesClose TokenColon CallableReturnType
+	= TokenIdentifier TokenParenthesesOpen [CallableParameters] TokenParenthesesClose TokenColon CallableReturnType
 
 CallableParameters
 	= CallableParameter *(TokenComma CallableParameter)

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -382,6 +382,16 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				Lexer::TOKEN_OPEN_PARENTHESES
 			],
 			[
+				'?callable(): Foo',
+				new NullableTypeNode(
+					new CallableTypeNode(
+						new IdentifierTypeNode('callable'),
+						[],
+						new IdentifierTypeNode('Foo')
+					)
+				)
+			],
+			[
 				'(Foo\\Bar<array<mixed, string>, (int | (string<foo> & bar)[])> | Lorem)',
 				new UnionTypeNode([
 					new GenericTypeNode(

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -297,25 +297,21 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 			],
 			[
 				'callable(): Foo|Bar',
-				new UnionTypeNode([
-					new CallableTypeNode(
-						new IdentifierTypeNode('callable'),
-						[],
-						new IdentifierTypeNode('Foo')
-					),
-					new IdentifierTypeNode('Bar'),
-				]),
+				new CallableTypeNode(
+					new IdentifierTypeNode('callable'),
+					[],
+					new IdentifierTypeNode('Foo')
+				),
+				Lexer::TOKEN_UNION
 			],
 			[
 				'callable(): Foo&Bar',
-				new IntersectionTypeNode([
-					new CallableTypeNode(
-						new IdentifierTypeNode('callable'),
-						[],
-						new IdentifierTypeNode('Foo')
-					),
-					new IdentifierTypeNode('Bar'),
-				]),
+				new CallableTypeNode(
+					new IdentifierTypeNode('callable'),
+					[],
+					new IdentifierTypeNode('Foo')
+				),
+				Lexer::TOKEN_INTERSECTION
 			],
 			[
 				'callable(): (Foo|Bar)',
@@ -368,6 +364,22 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 					],
 					new IdentifierTypeNode('Foo')
 				),
+			],
+			[
+				'Foo|callable(): Bar',
+				new UnionTypeNode([
+					new IdentifierTypeNode('Foo'),
+					new IdentifierTypeNode('callable')
+				]),
+				Lexer::TOKEN_OPEN_PARENTHESES
+			],
+			[
+				'Foo&callable(): Bar',
+				new IntersectionTypeNode([
+					new IdentifierTypeNode('Foo'),
+					new IdentifierTypeNode('callable')
+				]),
+				Lexer::TOKEN_OPEN_PARENTHESES
 			],
 			[
 				'(Foo\\Bar<array<mixed, string>, (int | (string<foo> & bar)[])> | Lorem)',


### PR DESCRIPTION
this disallows using callable type directly in union and intersection