### PR TITLE
Fix doccomment

### DIFF
--- a/src/Ast/PhpDoc/ParamTagValueNode.php
+++ b/src/Ast/PhpDoc/ParamTagValueNode.php
@@ -13,7 +13,7 @@ class ParamTagValueNode implements PhpDocTagValueNode
 	/** @var bool */
 	public $isVariadic;
 
-	/** @var string (may be empty) */
+	/** @var string */
 	public $parameterName;
 
 	/** @var string (may be empty) */


### PR DESCRIPTION
`@param` tag without parameter name is not supported so `$parameterName` cannot be empty string