### PR TITLE
Enhance support for multiple line descriptions

### DIFF
--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -90,7 +90,7 @@ class PhpDocParser
 			}
 
 			// There's more text on a new line, ensure spacing.
-			$text .= ' ';
+			$text .= "\n";
 		}
 		$text = trim($text, " \t");
 

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -170,7 +170,18 @@ class PhpDocParser
 
 	private function parseDeprecatedTagValue(TokenIterator $tokens): Ast\PhpDoc\DeprecatedTagValueNode
 	{
-		$description = $this->parseOptionalDescription($tokens);
+		$description = '';
+		while ($tokens->currentTokenType() !== Lexer::TOKEN_CLOSE_PHPDOC) {
+			$description .= $tokens->joinUntil(Lexer::TOKEN_PHPDOC_EOL, Lexer::TOKEN_CLOSE_PHPDOC, Lexer::TOKEN_END);
+			$description = rtrim($description, " \t");
+			if ($tokens->currentTokenType() !== Lexer::TOKEN_PHPDOC_EOL) {
+				break;
+			}
+			// There's more text on a new line, ensure spacing.
+			$description .= ' ';
+			$tokens->next();
+		}
+		$description = rtrim($description, " \t");
 		return new Ast\PhpDoc\DeprecatedTagValueNode($description);
 	}
 

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -81,9 +81,6 @@ class PhpDocParser
 			// to be combined.
 			$tokens->pushSavePoint();
 			$tokens->next();
-			if ($tokens->currentTokenType() === Lexer::TOKEN_PHPDOC_EOL) {
-				$tokens->next();
-			}
 			if ($tokens->currentTokenType() !== Lexer::TOKEN_IDENTIFIER) {
 				$tokens->rollback();
 				break;

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -50,7 +50,11 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	 * @dataProvider provideMethodTagsData
 	 * @dataProvider provideSingleLinePhpDocData
 	 * @dataProvider provideMultiLinePhpDocData
+<<<<<<< HEAD
 	 * @dataProvider provideTemplateTagsData
+=======
+   * @dataProvider provideRealWorldExampleData
+>>>>>>> Add a real world example
 	 * @param string     $label
 	 * @param string     $input
 	 * @param PhpDocNode $expectedPhpDocNode
@@ -2259,7 +2263,6 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 		];
 	}
 
-
 	public function provideTemplateTagsData(): \Iterator
 	{
 		yield [
@@ -2361,4 +2364,83 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 		];
 	}
 
+	public function provideRealWorldExampleData(): \Iterator
+  {
+      yield [
+        'OK with two param and paragraph description',
+        <<<PHPDOC
+  /**
+   * Returns the schema for the field.
+   *
+   * This method is static because the field schema information is needed on
+   * creation of the field. FieldItemInterface objects instantiated at that
+   * time are not reliable as field settings might be missing.
+   *
+   * Computed fields having no schema should return an empty array.
+   *
+   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface \$field_definition
+   *   The field definition.
+   *
+   * @return array
+   *   An empty array if there is no schema, or an associative array with the
+   *   following key/value pairs:
+   *   - columns: An array of Schema API column specifications, keyed by column
+   *     name. The columns need to be a subset of the properties defined in
+   *     propertyDefinitions(). The 'not null' property is ignored if present,
+   *     as it is determined automatically by the storage controller depending
+   *     on the table layout and the property definitions. It is recommended to
+   *     avoid having the column definitions depend on field settings when
+   *     possible. No assumptions should be made on how storage engines
+   *     internally use the original column name to structure their storage.
+   *   - unique keys: (optional) An array of Schema API unique key definitions.
+   *     Only columns that appear in the 'columns' array are allowed.
+   *   - indexes: (optional) An array of Schema API index definitions. Only
+   *     columns that appear in the 'columns' array are allowed. Those indexes
+   *     will be used as default indexes. Field definitions can specify
+   *     additional indexes or, at their own risk, modify the default indexes
+   *     specified by the field-type module. Some storage engines might not
+   *     support indexes.
+   *   - foreign keys: (optional) An array of Schema API foreign key
+   *     definitions. Note, however, that the field data is not necessarily
+   *     stored in SQL. Also, the possible usage is limited, as you cannot
+   *     specify another field as related, only existing SQL tables,
+   *     such as {taxonomy_term_data}.
+   */
+PHPDOC,
+        new PhpDocNode([
+          new PhpDocTextNode('Returns the schema for the field. This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing. Computed fields having no schema should return an empty array.'),
+          // @todo the commented out items should be correct.
+          //new PhpDocTextNode('Returns the schema for the field.'),
+          new PhpDocTextNode(''),
+          //new PhpDocTextNode('This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing.'),
+          //new PhpDocTextNode(''),
+          //new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
+          new PhpDocTagNode(
+            '@param',
+            new ParamTagValueNode(
+              new IdentifierTypeNode('\Drupal\Core\Field\FieldStorageDefinitionInterface'),
+              false,
+              '$field_definition',
+              ''
+            )
+          ),
+          // @todo this should be the param description, but new line param descriptions are not handled.
+          new PhpDocTextNode('The field definition.'),
+          new PhpDocTextNode(''),
+          new PhpDocTagNode(
+            '@return',
+            new ReturnTagValueNode(
+              new IdentifierTypeNode('array'),
+              ''
+            )
+          ),
+          // @todo these are actually the @return description.
+          new PhpDocTextNode('An empty array if there is no schema, or an associative array with the following key/value pairs:'),
+          new PhpDocTextNode('- columns: An array of Schema API column specifications, keyed by column name. The columns need to be a subset of the properties defined in propertyDefinitions(). The \'not null\' property is ignored if present, as it is determined automatically by the storage controller depending on the table layout and the property definitions. It is recommended to avoid having the column definitions depend on field settings when possible. No assumptions should be made on how storage engines internally use the original column name to structure their storage.'),
+          new PhpDocTextNode('- unique keys: (optional) An array of Schema API unique key definitions. Only columns that appear in the \'columns\' array are allowed.'),
+          new PhpDocTextNode('- indexes: (optional) An array of Schema API index definitions. Only columns that appear in the \'columns\' array are allowed. Those indexes will be used as default indexes. Field definitions can specify additional indexes or, at their own risk, modify the default indexes specified by the field-type module. Some storage engines might not support indexes.'),
+          new PhpDocTextNode('- foreign keys: (optional) An array of Schema API foreign key definitions. Note, however, that the field data is not necessarily stored in SQL. Also, the possible usage is limited, as you cannot specify another field as related, only existing SQL tables, such as {taxonomy_term_data}.'),
+        ]),
+      ];
+  }
 }

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -51,7 +51,7 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	 * @dataProvider provideSingleLinePhpDocData
 	 * @dataProvider provideMultiLinePhpDocData
 	 * @dataProvider provideTemplateTagsData
-   * @dataProvider provideRealWorldExampleData
+	 * @dataProvider provideRealWorldExampleData
 	 * @param string     $label
 	 * @param string     $input
 	 * @param PhpDocNode $expectedPhpDocNode
@@ -2368,6 +2368,32 @@ some text in the middle'
 		];
 	}
 
+	public function providerDebug(): \Iterator
+	{
+		$sample = '/**
+			 * Returns the schema for the field.
+			 *
+			 * This method is static because the field schema information is needed on
+			 * creation of the field. FieldItemInterface objects instantiated at that
+			 * time are not reliable as field settings might be missing.
+			 *
+			 * Computed fields having no schema should return an empty array.
+			 */';
+		yield [
+			'OK class line',
+			$sample,
+			new PhpDocNode([
+				new PhpDocTextNode('Returns the schema for the field.'),
+				new PhpDocTextNode(''),
+				new PhpDocTextNode('This method is static because the field schema information is needed on
+creation of the field. FieldItemInterface objects instantiated at that
+time are not reliable as field settings might be missing.'),
+				new PhpDocTextNode(''),
+				new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
+			]),
+		];
+	}
+
 	public function provideRealWorldExampleData(): \Iterator
 	{
 			$sample = "/**
@@ -2408,20 +2434,17 @@ some text in the middle'
 			 *     such as {taxonomy_term_data}.
 			 */";
 		yield [
-			'OK with two param and paragraph description',
+			'OK FieldItemInterface::schema',
 			$sample,
 			new PhpDocNode([
-				new PhpDocTextNode('Returns the schema for the field.
-This method is static because the field schema information is needed on
-creation of the field. FieldItemInterface objects instantiated at that
-time are not reliable as field settings might be missing.
-Computed fields having no schema should return an empty array.'),
-		  // @todo the commented out items should be correct.
-		  //new PhpDocTextNode('Returns the schema for the field.'),
+				new PhpDocTextNode('Returns the schema for the field.'),
 				new PhpDocTextNode(''),
-		  //new PhpDocTextNode('This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing.'),
-		  //new PhpDocTextNode(''),
-		  //new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
+				new PhpDocTextNode('This method is static because the field schema information is needed on
+creation of the field. FieldItemInterface objects instantiated at that
+time are not reliable as field settings might be missing.'),
+				new PhpDocTextNode(''),
+				new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
+				new PhpDocTextNode(''),
 				new PhpDocTagNode(
 					'@param',
 					new ParamTagValueNode(
@@ -2463,6 +2486,59 @@ definitions. Note, however, that the field data is not necessarily
 stored in SQL. Also, the possible usage is limited, as you cannot
 specify another field as related, only existing SQL tables,
 such as {taxonomy_term_data}.'),
+			]),
+		];
+
+		$sample = '/**
+     *  Parses a chunked request and return relevant information.
+     *
+     *  This function must return an array containing the following
+     *  keys and their corresponding values:
+     *    - last: Wheter this is the last chunk of the uploaded file
+     *    - uuid: A unique id which distinguishes two uploaded files
+     *            This uuid must stay the same among the task of
+     *            uploading a chunked file.
+     *    - index: A numerical representation of the currently uploaded
+     *            chunk. Must be higher that in the previous request.
+     *    - orig: The original file name.
+     *
+     * @param Request $request - The request object
+     *
+     * @return array
+     */';
+		yield [
+			'OK AbstractChunkedController::parseChunkedRequest',
+			$sample,
+			new PhpDocNode([
+				new PhpDocTextNode('Parses a chunked request and return relevant information.'),
+				new PhpDocTextNode(''),
+				new PhpDocTextNode('This function must return an array containing the following
+keys and their corresponding values:'),
+				new PhpDocTextNode('- last: Wheter this is the last chunk of the uploaded file'),
+				new PhpDocTextNode('- uuid: A unique id which distinguishes two uploaded files
+This uuid must stay the same among the task of
+uploading a chunked file.'),
+				new PhpDocTextNode('- index: A numerical representation of the currently uploaded
+chunk. Must be higher that in the previous request.'),
+				new PhpDocTextNode('- orig: The original file name.'),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@param',
+					new ParamTagValueNode(
+						new IdentifierTypeNode('Request'),
+						false,
+						'$request',
+						'- The request object'
+					)
+				),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new IdentifierTypeNode('array'),
+						''
+					)
+				),
 			]),
 		];
 	}

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -50,11 +50,8 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	 * @dataProvider provideMethodTagsData
 	 * @dataProvider provideSingleLinePhpDocData
 	 * @dataProvider provideMultiLinePhpDocData
-<<<<<<< HEAD
 	 * @dataProvider provideTemplateTagsData
-=======
    * @dataProvider provideRealWorldExampleData
->>>>>>> Add a real world example
 	 * @param string     $label
 	 * @param string     $input
 	 * @param PhpDocNode $expectedPhpDocNode
@@ -1000,9 +997,9 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 		];
 		yield [
 			'OK with two simple description with break',
-			'/** @deprecated text first 
+			'/** @deprecated text first
         *
-        * @deprecated text second 
+        * @deprecated text second
         */',
 			new PhpDocNode([
 				new PhpDocTagNode(
@@ -1019,8 +1016,8 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 
 		yield [
 			'OK with two simple description without break',
-			'/** @deprecated text first 
-        * @deprecated text second 
+			'/** @deprecated text first
+        * @deprecated text second
         */',
 			new PhpDocNode([
 				new PhpDocTagNode(
@@ -1051,13 +1048,13 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 			'OK with multiple and long descriptions',
 			'/**
       * Sample class
-      * 
+      *
       * @author Foo Baz <foo@baz.com>
-      * 
+      *
       * @deprecated in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In
 			*   Drupal 9 there will be no way to set the status and in Drupal 8 this
 			*   ability has been removed because mb_*() functions are supplied using
-			*   Symfony\'s polyfill. 
+			*   Symfony\'s polyfill.
 			*/',
 			new PhpDocNode([
 				new PhpDocTextNode('Sample class'),
@@ -2365,82 +2362,82 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	}
 
 	public function provideRealWorldExampleData(): \Iterator
-  {
-      yield [
-        'OK with two param and paragraph description',
-        <<<PHPDOC
-  /**
-   * Returns the schema for the field.
-   *
-   * This method is static because the field schema information is needed on
-   * creation of the field. FieldItemInterface objects instantiated at that
-   * time are not reliable as field settings might be missing.
-   *
-   * Computed fields having no schema should return an empty array.
-   *
-   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface \$field_definition
-   *   The field definition.
-   *
-   * @return array
-   *   An empty array if there is no schema, or an associative array with the
-   *   following key/value pairs:
-   *   - columns: An array of Schema API column specifications, keyed by column
-   *     name. The columns need to be a subset of the properties defined in
-   *     propertyDefinitions(). The 'not null' property is ignored if present,
-   *     as it is determined automatically by the storage controller depending
-   *     on the table layout and the property definitions. It is recommended to
-   *     avoid having the column definitions depend on field settings when
-   *     possible. No assumptions should be made on how storage engines
-   *     internally use the original column name to structure their storage.
-   *   - unique keys: (optional) An array of Schema API unique key definitions.
-   *     Only columns that appear in the 'columns' array are allowed.
-   *   - indexes: (optional) An array of Schema API index definitions. Only
-   *     columns that appear in the 'columns' array are allowed. Those indexes
-   *     will be used as default indexes. Field definitions can specify
-   *     additional indexes or, at their own risk, modify the default indexes
-   *     specified by the field-type module. Some storage engines might not
-   *     support indexes.
-   *   - foreign keys: (optional) An array of Schema API foreign key
-   *     definitions. Note, however, that the field data is not necessarily
-   *     stored in SQL. Also, the possible usage is limited, as you cannot
-   *     specify another field as related, only existing SQL tables,
-   *     such as {taxonomy_term_data}.
-   */
-PHPDOC,
-        new PhpDocNode([
-          new PhpDocTextNode('Returns the schema for the field. This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing. Computed fields having no schema should return an empty array.'),
-          // @todo the commented out items should be correct.
-          //new PhpDocTextNode('Returns the schema for the field.'),
-          new PhpDocTextNode(''),
-          //new PhpDocTextNode('This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing.'),
-          //new PhpDocTextNode(''),
-          //new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
-          new PhpDocTagNode(
-            '@param',
-            new ParamTagValueNode(
-              new IdentifierTypeNode('\Drupal\Core\Field\FieldStorageDefinitionInterface'),
-              false,
-              '$field_definition',
-              ''
-            )
-          ),
-          // @todo this should be the param description, but new line param descriptions are not handled.
-          new PhpDocTextNode('The field definition.'),
-          new PhpDocTextNode(''),
-          new PhpDocTagNode(
-            '@return',
-            new ReturnTagValueNode(
-              new IdentifierTypeNode('array'),
-              ''
-            )
-          ),
-          // @todo these are actually the @return description.
-          new PhpDocTextNode('An empty array if there is no schema, or an associative array with the following key/value pairs:'),
-          new PhpDocTextNode('- columns: An array of Schema API column specifications, keyed by column name. The columns need to be a subset of the properties defined in propertyDefinitions(). The \'not null\' property is ignored if present, as it is determined automatically by the storage controller depending on the table layout and the property definitions. It is recommended to avoid having the column definitions depend on field settings when possible. No assumptions should be made on how storage engines internally use the original column name to structure their storage.'),
-          new PhpDocTextNode('- unique keys: (optional) An array of Schema API unique key definitions. Only columns that appear in the \'columns\' array are allowed.'),
-          new PhpDocTextNode('- indexes: (optional) An array of Schema API index definitions. Only columns that appear in the \'columns\' array are allowed. Those indexes will be used as default indexes. Field definitions can specify additional indexes or, at their own risk, modify the default indexes specified by the field-type module. Some storage engines might not support indexes.'),
-          new PhpDocTextNode('- foreign keys: (optional) An array of Schema API foreign key definitions. Note, however, that the field data is not necessarily stored in SQL. Also, the possible usage is limited, as you cannot specify another field as related, only existing SQL tables, such as {taxonomy_term_data}.'),
-        ]),
-      ];
-  }
+	{
+			$sample = "/**
+			 * Returns the schema for the field.
+			 *
+			 * This method is static because the field schema information is needed on
+			 * creation of the field. FieldItemInterface objects instantiated at that
+			 * time are not reliable as field settings might be missing.
+			 *
+			 * Computed fields having no schema should return an empty array.
+			 *
+			 * @param \Drupal\Core\Field\FieldStorageDefinitionInterface \$field_definition
+			 *   The field definition.
+			 *
+			 * @return array
+			 *   An empty array if there is no schema, or an associative array with the
+			 *   following key/value pairs:
+			 *   - columns: An array of Schema API column specifications, keyed by column
+			 *     name. The columns need to be a subset of the properties defined in
+			 *     propertyDefinitions(). The 'not null' property is ignored if present,
+			 *     as it is determined automatically by the storage controller depending
+			 *     on the table layout and the property definitions. It is recommended to
+			 *     avoid having the column definitions depend on field settings when
+			 *     possible. No assumptions should be made on how storage engines
+			 *     internally use the original column name to structure their storage.
+			 *   - unique keys: (optional) An array of Schema API unique key definitions.
+			 *     Only columns that appear in the 'columns' array are allowed.
+			 *   - indexes: (optional) An array of Schema API index definitions. Only
+			 *     columns that appear in the 'columns' array are allowed. Those indexes
+			 *     will be used as default indexes. Field definitions can specify
+			 *     additional indexes or, at their own risk, modify the default indexes
+			 *     specified by the field-type module. Some storage engines might not
+			 *     support indexes.
+			 *   - foreign keys: (optional) An array of Schema API foreign key
+			 *     definitions. Note, however, that the field data is not necessarily
+			 *     stored in SQL. Also, the possible usage is limited, as you cannot
+			 *     specify another field as related, only existing SQL tables,
+			 *     such as {taxonomy_term_data}.
+			 */";
+		yield [
+			'OK with two param and paragraph description',
+			$sample,
+			new PhpDocNode([
+				new PhpDocTextNode('Returns the schema for the field. This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing. Computed fields having no schema should return an empty array.'),
+		  // @todo the commented out items should be correct.
+		  //new PhpDocTextNode('Returns the schema for the field.'),
+				new PhpDocTextNode(''),
+		  //new PhpDocTextNode('This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing.'),
+		  //new PhpDocTextNode(''),
+		  //new PhpDocTextNode('Computed fields having no schema should return an empty array.'),
+				new PhpDocTagNode(
+					'@param',
+					new ParamTagValueNode(
+						new IdentifierTypeNode('\Drupal\Core\Field\FieldStorageDefinitionInterface'),
+						false,
+						'$field_definition',
+						''
+					)
+				),
+			// @todo this should be the param description, but new line param descriptions are not handled.
+				new PhpDocTextNode('The field definition.'),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new IdentifierTypeNode('array'),
+						''
+					)
+				),
+			// @todo these are actually the @return description.
+				new PhpDocTextNode('An empty array if there is no schema, or an associative array with the following key/value pairs:'),
+				new PhpDocTextNode('- columns: An array of Schema API column specifications, keyed by column name. The columns need to be a subset of the properties defined in propertyDefinitions(). The \'not null\' property is ignored if present, as it is determined automatically by the storage controller depending on the table layout and the property definitions. It is recommended to avoid having the column definitions depend on field settings when possible. No assumptions should be made on how storage engines internally use the original column name to structure their storage.'),
+				new PhpDocTextNode('- unique keys: (optional) An array of Schema API unique key definitions. Only columns that appear in the \'columns\' array are allowed.'),
+				new PhpDocTextNode('- indexes: (optional) An array of Schema API index definitions. Only columns that appear in the \'columns\' array are allowed. Those indexes will be used as default indexes. Field definitions can specify additional indexes or, at their own risk, modify the default indexes specified by the field-type module. Some storage engines might not support indexes.'),
+				new PhpDocTextNode('- foreign keys: (optional) An array of Schema API foreign key definitions. Note, however, that the field data is not necessarily stored in SQL. Also, the possible usage is limited, as you cannot specify another field as related, only existing SQL tables, such as {taxonomy_term_data}.'),
+			]),
+		];
+	}
+
 }

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -994,6 +994,41 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 				),
 			]),
 		];
+		yield [
+			'OK with two simple description with break',
+			'/** @deprecated text first 
+        *
+        * @deprecated text second 
+        */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@deprecated',
+					new DeprecatedTagValueNode('text first')
+				),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@deprecated',
+					new DeprecatedTagValueNode('text second')
+				),
+			]),
+		];
+
+		yield [
+			'OK with two simple description without break',
+			'/** @deprecated text first 
+        * @deprecated text second 
+        */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@deprecated',
+					new DeprecatedTagValueNode('text first')
+				),
+				new PhpDocTagNode(
+					'@deprecated',
+					new DeprecatedTagValueNode('text second')
+				),
+			]),
+		];
 
 		yield [
 			'OK with long descriptions',
@@ -1543,10 +1578,9 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 							new IdentifierTypeNode('Foo'),
 							false,
 							'$foo',
-							'1st multi world description'
+							'1st multi world description some text in the middle'
 						)
 					),
-					new PhpDocTextNode('some text in the middle'),
 					new PhpDocTagNode(
 						'@param',
 						new ParamTagValueNode(
@@ -1563,15 +1597,16 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 				'/**
 				  *
 				  *
-				  * @param Foo $foo 1st multi world description
+				  * @param Foo $foo 1st multi world description with empty lines
 				  *
 				  *
 				  * some text in the middle
 				  *
 				  *
-				  * @param Bar $bar 2nd multi world description
+				  * @param Bar $bar 2nd multi world description with empty lines
 				  *
 				  *
+				  * test
 				  */',
 				new PhpDocNode([
 					new PhpDocTextNode(''),
@@ -1582,7 +1617,7 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 							new IdentifierTypeNode('Foo'),
 							false,
 							'$foo',
-							'1st multi world description'
+							'1st multi world description with empty lines'
 						)
 					),
 					new PhpDocTextNode(''),
@@ -1596,11 +1631,12 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 							new IdentifierTypeNode('Bar'),
 							false,
 							'$bar',
-							'2nd multi world description'
+							'2nd multi world description with empty lines'
 						)
 					),
 					new PhpDocTextNode(''),
 					new PhpDocTextNode(''),
+					new PhpDocTextNode('test'),
 				]),
 			],
 			[

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -1004,11 +1004,34 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@deprecated',
-					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In')
+					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In Drupal 9 there will be no way to set the status and in Drupal 8 this ability has been removed because mb_*() functions are supplied using Symfony\'s polyfill.')
 				),
-				new PhpDocTextNode('Drupal 9 there will be no way to set the status and in Drupal 8 this'),
-				new PhpDocTextNode('ability has been removed because mb_*() functions are supplied using'),
-				new PhpDocTextNode('Symfony\'s polyfill.'),
+			]),
+		];
+		yield [
+			'OK with multiple and long descriptions',
+			'/**
+      * Sample class
+      * 
+      * @author Foo Baz <foo@baz.com>
+      * 
+      * @deprecated in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In
+			*   Drupal 9 there will be no way to set the status and in Drupal 8 this
+			*   ability has been removed because mb_*() functions are supplied using
+			*   Symfony\'s polyfill. 
+			*/',
+			new PhpDocNode([
+				new PhpDocTextNode('Sample class'),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@author',
+					new GenericTagValueNode('Foo Baz <foo@baz.com>')
+				),
+				new PhpDocTextNode(''),
+				new PhpDocTagNode(
+					'@deprecated',
+					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In Drupal 9 there will be no way to set the status and in Drupal 8 this ability has been removed because mb_*() functions are supplied using Symfony\'s polyfill.')
+				),
 			]),
 		];
 	}

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -1040,7 +1040,10 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@deprecated',
-					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In Drupal 9 there will be no way to set the status and in Drupal 8 this ability has been removed because mb_*() functions are supplied using Symfony\'s polyfill.')
+					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In
+Drupal 9 there will be no way to set the status and in Drupal 8 this
+ability has been removed because mb_*() functions are supplied using
+Symfony\'s polyfill.')
 				),
 			]),
 		];
@@ -1066,7 +1069,10 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 				new PhpDocTextNode(''),
 				new PhpDocTagNode(
 					'@deprecated',
-					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In Drupal 9 there will be no way to set the status and in Drupal 8 this ability has been removed because mb_*() functions are supplied using Symfony\'s polyfill.')
+					new DeprecatedTagValueNode('in Drupal 8.6.0 and will be removed before Drupal 9.0.0. In
+Drupal 9 there will be no way to set the status and in Drupal 8 this
+ability has been removed because mb_*() functions are supplied using
+Symfony\'s polyfill.')
 				),
 			]),
 		];
@@ -1579,7 +1585,8 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 							new IdentifierTypeNode('Foo'),
 							false,
 							'$foo',
-							'1st multi world description some text in the middle'
+							'1st multi world description
+some text in the middle'
 						)
 					),
 					new PhpDocTagNode(
@@ -2404,7 +2411,11 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 			'OK with two param and paragraph description',
 			$sample,
 			new PhpDocNode([
-				new PhpDocTextNode('Returns the schema for the field. This method is static because the field schema information is needed on creation of the field. FieldItemInterface objects instantiated at that time are not reliable as field settings might be missing. Computed fields having no schema should return an empty array.'),
+				new PhpDocTextNode('Returns the schema for the field.
+This method is static because the field schema information is needed on
+creation of the field. FieldItemInterface objects instantiated at that
+time are not reliable as field settings might be missing.
+Computed fields having no schema should return an empty array.'),
 		  // @todo the commented out items should be correct.
 		  //new PhpDocTextNode('Returns the schema for the field.'),
 				new PhpDocTextNode(''),
@@ -2420,7 +2431,6 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 						''
 					)
 				),
-			// @todo this should be the param description, but new line param descriptions are not handled.
 				new PhpDocTextNode('The field definition.'),
 				new PhpDocTextNode(''),
 				new PhpDocTagNode(
@@ -2430,12 +2440,29 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 						''
 					)
 				),
-			// @todo these are actually the @return description.
-				new PhpDocTextNode('An empty array if there is no schema, or an associative array with the following key/value pairs:'),
-				new PhpDocTextNode('- columns: An array of Schema API column specifications, keyed by column name. The columns need to be a subset of the properties defined in propertyDefinitions(). The \'not null\' property is ignored if present, as it is determined automatically by the storage controller depending on the table layout and the property definitions. It is recommended to avoid having the column definitions depend on field settings when possible. No assumptions should be made on how storage engines internally use the original column name to structure their storage.'),
-				new PhpDocTextNode('- unique keys: (optional) An array of Schema API unique key definitions. Only columns that appear in the \'columns\' array are allowed.'),
-				new PhpDocTextNode('- indexes: (optional) An array of Schema API index definitions. Only columns that appear in the \'columns\' array are allowed. Those indexes will be used as default indexes. Field definitions can specify additional indexes or, at their own risk, modify the default indexes specified by the field-type module. Some storage engines might not support indexes.'),
-				new PhpDocTextNode('- foreign keys: (optional) An array of Schema API foreign key definitions. Note, however, that the field data is not necessarily stored in SQL. Also, the possible usage is limited, as you cannot specify another field as related, only existing SQL tables, such as {taxonomy_term_data}.'),
+				new PhpDocTextNode('An empty array if there is no schema, or an associative array with the
+following key/value pairs:'),
+				new PhpDocTextNode('- columns: An array of Schema API column specifications, keyed by column
+name. The columns need to be a subset of the properties defined in
+propertyDefinitions(). The \'not null\' property is ignored if present,
+as it is determined automatically by the storage controller depending
+on the table layout and the property definitions. It is recommended to
+avoid having the column definitions depend on field settings when
+possible. No assumptions should be made on how storage engines
+internally use the original column name to structure their storage.'),
+				new PhpDocTextNode('- unique keys: (optional) An array of Schema API unique key definitions.
+Only columns that appear in the \'columns\' array are allowed.'),
+				new PhpDocTextNode('- indexes: (optional) An array of Schema API index definitions. Only
+columns that appear in the \'columns\' array are allowed. Those indexes
+will be used as default indexes. Field definitions can specify
+additional indexes or, at their own risk, modify the default indexes
+specified by the field-type module. Some storage engines might not
+support indexes.'),
+				new PhpDocTextNode('- foreign keys: (optional) An array of Schema API foreign key
+definitions. Note, however, that the field data is not necessarily
+stored in SQL. Also, the possible usage is limited, as you cannot
+specify another field as related, only existing SQL tables,
+such as {taxonomy_term_data}.'),
 			]),
 		];
 	}


### PR DESCRIPTION
I didn't want to touch \PHPStan\PhpDocParser\Parser\TokenIterator, which I think could be refactored to properly implement the \Iterator interface. That seemed like a task of its own.

This loops over the tokens passed to `\PHPStan\PhpDocParser\Parser\PhpDocParser::parseDeprecatedTagValue` and builds the entire message.

