### PR TITLE
Array shapes support

### DIFF
--- a/doc/grammars/type.abnf
+++ b/doc/grammars/type.abnf
@@ -52,6 +52,12 @@ CallableReturnType
 Array
 	= 1*(TokenSquareBracketOpen TokenSquareBracketClose)
 
+ArrayShape
+    = TokenCurlyBracketOpen ArrayShapeItem *(TokenComma ArrayShapeItem) TokenCurlyBracketClose
+
+ArrayShapeItem
+    = (ConstantString / ConstantInt / TokenIdentifier) TokenNullable TokenColon Type
+    / Type
 
 ; ---------------------------------------------------------------------------- ;
 ;  ConstantExpr                                                                ;
@@ -138,6 +144,12 @@ TokenSquareBracketOpen
 
 TokenSquareBracketClose
 	= "]" *ByteHorizontalWs
+
+TokenCurlyBracketOpen
+    = "{" *ByteHorizontalWs
+
+TokenCurlyBracketClose
+    = "}" *ByteHorizontalWs
 
 TokenComma
 	= "," *ByteHorizontalWs

--- a/src/Ast/Type/ArrayShapeItemNode.php
+++ b/src/Ast/Type/ArrayShapeItemNode.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\Type;
+
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+
+class ArrayShapeItemNode implements TypeNode
+{
+
+	/** @var ConstExprStringNode|ConstExprIntegerNode|IdentifierTypeNode|null */
+	public $keyName;
+
+	/** @var bool */
+	public $optional;
+
+	/** @var TypeNode */
+	public $valueType;
+
+	/**
+	 * @param ConstExprStringNode|ConstExprIntegerNode|IdentifierTypeNode|null $keyName
+	 */
+	public function __construct($keyName, bool $optional, TypeNode $valueType)
+	{
+		$this->keyName = $keyName;
+		$this->optional = $optional;
+		$this->valueType = $valueType;
+	}
+
+
+	public function __toString(): string
+	{
+		if ($this->keyName !== null) {
+			return sprintf(
+				'%s%s: %s',
+				(string) $this->keyName,
+				$this->optional ? '?' : '',
+				(string) $this->valueType
+			);
+		}
+
+		return (string) $this->valueType;
+	}
+
+}

--- a/src/Ast/Type/ArrayShapeItemNode.php
+++ b/src/Ast/Type/ArrayShapeItemNode.php
@@ -3,12 +3,11 @@
 namespace PHPStan\PhpDocParser\Ast\Type;
 
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 
 class ArrayShapeItemNode implements TypeNode
 {
 
-	/** @var ConstExprStringNode|ConstExprIntegerNode|IdentifierTypeNode|null */
+	/** @var ConstExprIntegerNode|IdentifierTypeNode|null */
 	public $keyName;
 
 	/** @var bool */
@@ -18,7 +17,7 @@ class ArrayShapeItemNode implements TypeNode
 	public $valueType;
 
 	/**
-	 * @param ConstExprStringNode|ConstExprIntegerNode|IdentifierTypeNode|null $keyName
+	 * @param ConstExprIntegerNode|IdentifierTypeNode|null $keyName
 	 */
 	public function __construct($keyName, bool $optional, TypeNode $valueType)
 	{

--- a/src/Ast/Type/ArrayShapeNode.php
+++ b/src/Ast/Type/ArrayShapeNode.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\Type;
+
+class ArrayShapeNode implements TypeNode
+{
+
+	/** @var ArrayShapeItemNode[] */
+	public $items;
+
+	public function __construct(array $items)
+	{
+		$this->items = $items;
+	}
+
+
+	public function __toString(): string
+	{
+		return 'array{' . implode(', ', $this->items) . '}';
+	}
+
+}

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -18,6 +18,8 @@ class Lexer
 	public const TOKEN_CLOSE_ANGLE_BRACKET = 7;
 	public const TOKEN_OPEN_SQUARE_BRACKET = 8;
 	public const TOKEN_CLOSE_SQUARE_BRACKET = 9;
+	public const TOKEN_OPEN_CURLY_BRACKET = 30;
+	public const TOKEN_CLOSE_CURLY_BRACKET = 31;
 	public const TOKEN_COMMA = 10;
 	public const TOKEN_COLON = 29;
 	public const TOKEN_VARIADIC = 11;
@@ -50,6 +52,8 @@ class Lexer
 		self::TOKEN_CLOSE_ANGLE_BRACKET => '\'>\'',
 		self::TOKEN_OPEN_SQUARE_BRACKET => '\'[\'',
 		self::TOKEN_CLOSE_SQUARE_BRACKET => '\']\'',
+		self::TOKEN_OPEN_CURLY_BRACKET => '\'{\'',
+		self::TOKEN_CLOSE_CURLY_BRACKET => '\'}\'',
 		self::TOKEN_COMMA => '\',\'',
 		self::TOKEN_COLON => '\':\'',
 		self::TOKEN_VARIADIC => '\'...\'',
@@ -123,6 +127,8 @@ class Lexer
 			self::TOKEN_CLOSE_ANGLE_BRACKET => '>',
 			self::TOKEN_OPEN_SQUARE_BRACKET => '\\[',
 			self::TOKEN_CLOSE_SQUARE_BRACKET => '\\]',
+			self::TOKEN_OPEN_CURLY_BRACKET => '\\{',
+			self::TOKEN_CLOSE_CURLY_BRACKET => '\\}',
 
 			self::TOKEN_COMMA => ',',
 			self::TOKEN_VARIADIC => '\\.\\.\\.',

--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -64,6 +64,12 @@ class TokenIterator
 	}
 
 
+	public function isPrecededByHorizontalWhitespace(): bool
+	{
+		return ($this->tokens[$this->index - 1][Lexer::TYPE_OFFSET] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
+	}
+
+
 	/**
 	 * @param  int $tokenType
 	 * @throws \PHPStan\PhpDocParser\Parser\ParserException

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -253,19 +253,11 @@ class TypeParser
 	}
 
 	/**
-	 * @return Ast\ConstExpr\ConstExprStringNode|Ast\ConstExpr\ConstExprIntegerNode|Ast\Type\IdentifierTypeNode
+	 * @return Ast\ConstExpr\ConstExprIntegerNode|Ast\Type\IdentifierTypeNode
 	 */
 	private function parseArrayShapeKey(TokenIterator $tokens)
 	{
-		if ($tokens->isCurrentTokenType(Lexer::TOKEN_SINGLE_QUOTED_STRING)) {
-			$key = new Ast\ConstExpr\ConstExprStringNode($tokens->currentTokenValue());
-			$tokens->next();
-
-		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_DOUBLE_QUOTED_STRING)) {
-			$key = new Ast\ConstExpr\ConstExprStringNode($tokens->currentTokenValue());
-			$tokens->next();
-
-		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_INTEGER)) {
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_INTEGER)) {
 			$key = new Ast\ConstExpr\ConstExprIntegerNode($tokens->currentTokenValue());
 			$tokens->next();
 

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -54,7 +54,7 @@ class TypeParser
 			} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
 				$type = $this->tryParseArray($tokens, $type);
 
-			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET)) {
+			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
 				$type = $this->parseArrayShape($tokens, $type);
 			}
 		}
@@ -97,7 +97,7 @@ class TypeParser
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
 			$type = $this->parseGeneric($tokens, $type);
 
-		} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET)) {
+		} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
 			$type = $this->parseArrayShape($tokens, $type);
 		}
 
@@ -174,7 +174,7 @@ class TypeParser
 			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
 				$type = $this->parseGeneric($tokens, $type);
 
-			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET)) {
+			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
 				$type = $this->parseArrayShape($tokens, $type);
 			}
 		}

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -448,6 +448,24 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				),
 			],
 			[
+				'array{"a": int}',
+				new \PHPStan\PhpDocParser\Parser\ParserException(
+					'"a"',
+					Lexer::TOKEN_DOUBLE_QUOTED_STRING,
+					6,
+					Lexer::TOKEN_IDENTIFIER
+				),
+			],
+			[
+				'array{\'a\': int}',
+				new \PHPStan\PhpDocParser\Parser\ParserException(
+					'\'a\'',
+					Lexer::TOKEN_SINGLE_QUOTED_STRING,
+					6,
+					Lexer::TOKEN_IDENTIFIER
+				),
+			],
+			[
 				'callable(): Foo',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -2,6 +2,10 @@
 
 namespace PHPStan\PhpDocParser\Parser;
 
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeParameterNode;
@@ -265,6 +269,142 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				),
 			],
 			[
+				'array{\'a\': int}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'a\''),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				]),
+			],
+			[
+				'array{\'a\': ?int}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'a\''),
+						false,
+						new NullableTypeNode(
+							new IdentifierTypeNode('int')
+						)
+					),
+				]),
+			],
+			[
+				'array{\'a\'?: ?int}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'a\''),
+						true,
+						new NullableTypeNode(
+							new IdentifierTypeNode('int')
+						)
+					),
+				]),
+			],
+			[
+				'array{\'a\': int, \'b\': string}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'a\''),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'b\''),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
+				'array{int, string, "a": string}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('string')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('"a"'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
+				'array{"a"?: int, \'b\': string, 0: int, 1?: DateTime, hello: string}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('"a"'),
+						true,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'b\''),
+						false,
+						new IdentifierTypeNode('string')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprIntegerNode('0'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprIntegerNode('1'),
+						true,
+						new IdentifierTypeNode('DateTime')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('hello'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
+				'array{\'a\': int, \'b\': array{\'c\': callable(): int}}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'a\''),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new ConstExprStringNode('\'b\''),
+						false,
+						new ArrayShapeNode([
+							new ArrayShapeItemNode(
+								new ConstExprStringNode('\'c\''),
+								false,
+								new CallableTypeNode(
+									new IdentifierTypeNode('callable'),
+									[],
+									new IdentifierTypeNode('int')
+								)
+							),
+						])
+					),
+				]),
+			],
+			[
+				'?array{\'a\': int}',
+				new NullableTypeNode(
+					new ArrayShapeNode([
+						new ArrayShapeItemNode(
+							new ConstExprStringNode('\'a\''),
+							false,
+							new IdentifierTypeNode('int')
+						),
+					])
+				),
+			],
+			[
 				'callable(): Foo',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),
@@ -336,6 +476,20 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 					new IntersectionTypeNode([
 						new IdentifierTypeNode('Foo'),
 						new IdentifierTypeNode('Bar'),
+					])
+				),
+			],
+			[
+				'callable(): array{\'a\': int}',
+				new CallableTypeNode(
+					new IdentifierTypeNode('callable'),
+					[],
+					new ArrayShapeNode([
+						new ArrayShapeItemNode(
+							new ConstExprStringNode('\'a\''),
+							false,
+							new IdentifierTypeNode('int')
+						),
 					])
 				),
 			],

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -3,7 +3,6 @@
 namespace PHPStan\PhpDocParser\Parser;
 
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -280,20 +279,20 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 			],
 
 			[
-				'array{\'a\': int}',
+				'array{a: int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'a\''),
+						new IdentifierTypeNode('a'),
 						false,
 						new IdentifierTypeNode('int')
 					),
 				]),
 			],
 			[
-				'array{\'a\': ?int}',
+				'array{a: ?int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'a\''),
+						new IdentifierTypeNode('a'),
 						false,
 						new NullableTypeNode(
 							new IdentifierTypeNode('int')
@@ -302,10 +301,10 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'array{\'a\'?: ?int}',
+				'array{a?: ?int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'a\''),
+						new IdentifierTypeNode('a'),
 						true,
 						new NullableTypeNode(
 							new IdentifierTypeNode('int')
@@ -314,22 +313,27 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'array{\'a\': int, \'b\': string}',
+				'array{0: int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'a\''),
+						new ConstExprIntegerNode('0'),
 						false,
 						new IdentifierTypeNode('int')
-					),
-					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'b\''),
-						false,
-						new IdentifierTypeNode('string')
 					),
 				]),
 			],
 			[
-				'array{int, string, "a": string}',
+				'array{0?: int}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new ConstExprIntegerNode('0'),
+						true,
+						new IdentifierTypeNode('int')
+					),
+				]),
+			],
+			[
+				'array{int, int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
 						null,
@@ -339,25 +343,35 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 					new ArrayShapeItemNode(
 						null,
 						false,
-						new IdentifierTypeNode('string')
+						new IdentifierTypeNode('int')
+					),
+				]),
+			],
+			[
+				'array{a: int, b: string}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
 					),
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('"a"'),
+						new IdentifierTypeNode('b'),
 						false,
 						new IdentifierTypeNode('string')
 					),
 				]),
 			],
 			[
-				'array{"a"?: int, \'b\': string, 0: int, 1?: DateTime, hello: string}',
+				'array{a?: int, b: string, 0: int, 1?: DateTime, hello: string}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('"a"'),
+						new IdentifierTypeNode('a'),
 						true,
 						new IdentifierTypeNode('int')
 					),
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'b\''),
+						new IdentifierTypeNode('b'),
 						false,
 						new IdentifierTypeNode('string')
 					),
@@ -379,19 +393,19 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'array{\'a\': int, \'b\': array{\'c\': callable(): int}}',
+				'array{a: int, b: array{c: callable(): int}}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'a\''),
+						new IdentifierTypeNode('a'),
 						false,
 						new IdentifierTypeNode('int')
 					),
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('\'b\''),
+						new IdentifierTypeNode('b'),
 						false,
 						new ArrayShapeNode([
 							new ArrayShapeItemNode(
-								new ConstExprStringNode('\'c\''),
+								new IdentifierTypeNode('c'),
 								false,
 								new CallableTypeNode(
 									new IdentifierTypeNode('callable'),
@@ -404,11 +418,11 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'?array{\'a\': int}',
+				'?array{a: int}',
 				new NullableTypeNode(
 					new ArrayShapeNode([
 						new ArrayShapeItemNode(
-							new ConstExprStringNode('\'a\''),
+							new IdentifierTypeNode('a'),
 							false,
 							new IdentifierTypeNode('int')
 						),
@@ -509,13 +523,13 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				),
 			],
 			[
-				'callable(): array{\'a\': int}',
+				'callable(): array{a: int}',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),
 					[],
 					new ArrayShapeNode([
 						new ArrayShapeItemNode(
-							new ConstExprStringNode('\'a\''),
+							new IdentifierTypeNode('a'),
 							false,
 							new IdentifierTypeNode('int')
 						),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -269,6 +269,12 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				),
 			],
 			[
+				'array {\'a\': int}',
+				new IdentifierTypeNode('array'),
+				Lexer::TOKEN_OPEN_CURLY_BRACKET,
+			],
+
+			[
 				'array{\'a\': int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(


### PR DESCRIPTION
Adds support for parsing array shapes (object-like arrays).

Examples:

```
array{'foo': int, "bar": string}
array{0: int, 1?: int}
array{int, int}
array{foo: int, bar: string}
```

Keys can be single quoted strings, double quoted strings, integers, or identifiers (represented as ConstExprStringNode, ConstExprIntegerNode, IdentifierTypeNode).

They can be marked optional with a `?` before the key and the `:`.

They can be omitted entirely.

Values can be any type, including nullable types or nested array shapes.