### PR TITLE
Support multiple lines for array shape

### DIFF
--- a/src/Ast/PhpDoc/TemplateTagValueNode.php
+++ b/src/Ast/PhpDoc/TemplateTagValueNode.php
@@ -26,7 +26,7 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 
 	public function __toString(): string
 	{
-		$bound = $this->bound ? " of {$this->bound}" : '';
+		$bound = isset($this->bound) ? " of {$this->bound}" : '';
 		return trim("{$this->name}{$bound} {$this->description}");
 	}
 

--- a/src/Ast/PhpDoc/TemplateTagValueNode.php
+++ b/src/Ast/PhpDoc/TemplateTagValueNode.php
@@ -26,7 +26,7 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 
 	public function __toString(): string
 	{
-		$bound = isset($this->bound) ? " of {$this->bound}" : '';
+		$bound = $this->bound !== null ? " of {$this->bound}" : '';
 		return trim("{$this->name}{$bound} {$this->description}");
 	}
 

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -227,7 +227,7 @@ class TypeParser
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA)) {
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
-			if($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
+			if ($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
 				// trailing comma case
 				return new Ast\Type\ArrayShapeNode($items);
 			}

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -221,12 +221,15 @@ class TypeParser
 	private function parseArrayShape(TokenIterator $tokens, Ast\Type\TypeNode $type): Ast\Type\TypeNode
 	{
 		$tokens->consumeTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET);
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$items = [$this->parseArrayShapeItem($tokens)];
 
 		while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA)) {
+			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 			$items[] = $this->parseArrayShapeItem($tokens);
 		}
 
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET);
 
 		return new Ast\Type\ArrayShapeNode($items);

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -224,6 +224,7 @@ class TypeParser
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$items = [$this->parseArrayShapeItem($tokens)];
 
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA)) {
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 			if($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
@@ -232,6 +233,7 @@ class TypeParser
 			}
 
 			$items[] = $this->parseArrayShapeItem($tokens);
+			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		}
 
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -226,6 +226,11 @@ class TypeParser
 
 		while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA)) {
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
+			if($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
+				// trailing comma case
+				return new Ast\Type\ArrayShapeNode($items);
+			}
+
 			$items[] = $this->parseArrayShapeItem($tokens);
 		}
 

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -509,6 +509,30 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 			],
 			[
 				'array{
+				 	a: int
+				 	, b: string
+				 	, c: string
+				 }',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('b'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('c'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
+				'array{
 				 	a: int,
 				 	b: string
 				 }',

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -478,6 +478,24 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
+				'array{
+				 	a: int,
+				 	b: string
+				 }',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('b'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
 				'callable(): Foo',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -393,7 +393,7 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-                'array{a: int, b: array{c: callable(): int}}',
+				'array{a: int, b: array{c: callable(): int}}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
 						new IdentifierTypeNode('a'),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -480,6 +480,36 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 			[
 				'array{
 				 	a: int,
+				 }',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				]),
+			],
+			[
+				'array{
+				 	a: int,
+				 	b: string,
+				 }',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('b'),
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
+				'array{
+				 	a: int,
 				 	b: string
 				 }',
 				new ArrayShapeNode([

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -393,12 +393,7 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'array{
-				    a: int, 
-				    b: array{
-				        c: callable(): int
-				    }
-				 }',
+                'array{a: int, b: array{c: callable(): int}}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
 						new IdentifierTypeNode('a'),
@@ -469,6 +464,18 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 					6,
 					Lexer::TOKEN_IDENTIFIER
 				),
+			],
+			[
+				'array{
+				 *	a: int
+				 *}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				]),
 			],
 			[
 				'callable(): Foo',

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -393,7 +393,12 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				]),
 			],
 			[
-				'array{a: int, b: array{c: callable(): int}}',
+				'array{
+				    a: int, 
+				    b: array{
+				        c: callable(): int
+				    }
+				 }',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
 						new IdentifierTypeNode('a'),


### PR DESCRIPTION
Possible fix for https://github.com/phpstan/phpstan/issues/2497

Hey there, great library, fantastic work to all involved. So, like a lot of folks I'm excited about using array shapes, but without multiline syntax it doesn't really seem practical. 

I haven't done much with parsers since my school days of long ago, and I was told that you have previously dismissed this idea as not feasible, so please tell me what I'm doing wrong.