### PR TITLE
Enhancement: Run ergebnis/composer-normalize in check target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,7 @@
 		composer-install,
 		lint,
 		cs,
+		composer-normalize-check,
 		tests,
 		phpstan
 	"/>
@@ -29,6 +30,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+				executable="composer"
+				logoutput="true"
+				passthru="true"
+				checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -7,25 +7,33 @@
 	},
 	"require-dev": {
 		"consistence/coding-standard": "^3.5",
+		"ergebnis/composer-normalize": "^2.0.2",
 		"jakub-onderka/php-parallel-lint": "^0.9.2",
 		"phing/phing": "^2.16.0",
+		"phpstan/extension-installer": "^1.0",
 		"phpstan/phpstan": "^0.12",
+		"phpstan/phpstan-strict-rules": "^0.12",
 		"phpunit/phpunit": "^6.3",
 		"slevomat/coding-standard": "^4.7.2",
-		"symfony/process": "^4.0",
-		"phpstan/extension-installer": "^1.0",
-		"phpstan/phpstan-strict-rules": "^0.12",
-		"ergebnis/composer-normalize": "^2.0.2"
-	},
-	"autoload": {
-		"psr-4": {"PHPStan\\PhpDocParser\\": ["src/"]}
-	},
-	"autoload-dev": {
-		"psr-4": {"PHPStan\\PhpDocParser\\": ["tests/PHPStan"]}
+		"symfony/process": "^4.0"
 	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.4-dev"
+		}
+	},
+	"autoload": {
+		"psr-4": {
+			"PHPStan\\PhpDocParser\\": [
+				"src/"
+			]
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"PHPStan\\PhpDocParser\\": [
+				"tests/PHPStan"
+			]
 		}
 	},
 	"minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
 		"slevomat/coding-standard": "^4.7.2",
 		"symfony/process": "^4.0",
 		"phpstan/extension-installer": "^1.0",
-		"phpstan/phpstan-strict-rules": "^0.12"
+		"phpstan/phpstan-strict-rules": "^0.12",
+		"ergebnis/composer-normalize": "^2.0.2"
 	},
 	"autoload": {
 		"psr-4": {"PHPStan\\PhpDocParser\\": ["src/"]}

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
 		"slevomat/coding-standard": "^4.7.2",
 		"symfony/process": "^4.0"
 	},
+	"config": {
+		"sort-packages": true
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.4-dev"


### PR DESCRIPTION
This PR

* [x] runs `ergebnis/composer-normalize` with the `--dry-run` option in the `check` target
* [x] runs `composer normalize`
* [x] keeps packages sorted in `composer.json`