### PR TITLE
⬆️  Upgrade PHP dependency to support PHP8 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - master
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "PHPDoc parser with support for nullable, intersection and generic types",
 	"license": "MIT",
 	"require": {
-		"php": "~7.1"
+		"php": "^7.1 || ^8.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "^3.5",


### PR DESCRIPTION
The release of PHP8 alpha approaching, it will be nice if the lib authorize installation without tweaking composer installation.