### PR TITLE
TypeParser: variadic arguments are always considered optional

### DIFF
--- a/src/Ast/Type/CallableTypeParameterNode.php
+++ b/src/Ast/Type/CallableTypeParameterNode.php
@@ -37,7 +37,7 @@ class CallableTypeParameterNode implements Node
 		$type = "{$this->type} ";
 		$isReference = $this->isReference ? '&' : '';
 		$isVariadic = $this->isVariadic ? '...' : '';
-		$default = $this->isOptional ? ' = default' : '';
+		$default = $this->isOptional && !$this->isVariadic ? ' = default' : '';
 		return "{$type}{$isReference}{$isVariadic}{$this->parameterName}{$default}";
 	}
 

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -258,7 +258,7 @@ class TypeParser
 			$parameterName = '';
 		}
 
-		$isOptional = $tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL);
+		$isOptional = $tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL) || $isVariadic;
 		return new Ast\Type\CallableTypeParameterNode($type, $isReference, $isVariadic, $parameterName, $isOptional);
 	}
 

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -828,7 +828,7 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 			[
 				'callable(mixed...): TReturn',
 				new CallableTypeNode(new IdentifierTypeNode('callable'), [
-					new CallableTypeParameterNode(new IdentifierTypeNode('mixed'), false, true, '', false),
+					new CallableTypeParameterNode(new IdentifierTypeNode('mixed'), false, true, '', true),
 				], new IdentifierTypeNode('TReturn')),
 			],
 			[


### PR DESCRIPTION
this fixes phpstan/phpstan#3798.
it's legal to pass zero arguments to a variadic parameter.
I've ensured that it's still possible to write things like `callable(int ...$foo=) : void` to preserve backwards compatibility, but really it should not be necessary or desirable to add the optional flag to a variadic parameter anyway.

