### PR TITLE
[cs] update coding standard to allow PHP 8 and Slevomat CS 6.4

### DIFF
--- a/build-cs/composer.json
+++ b/build-cs/composer.json
@@ -1,7 +1,10 @@
 {
+	"require": {
+		"php": "^7.1 || ^8.0"
+	},
 	"require-dev": {
-		"consistence/coding-standard": "^3.5",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"slevomat/coding-standard": "^4.7.2"
+		"consistence/coding-standard": "^3.10",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+		"slevomat/coding-standard": "^6.4.1"
 	}
 }

--- a/build.xml
+++ b/build.xml
@@ -60,6 +60,7 @@
 			<arg value="install"/>
 			<arg value="--working-dir"/>
 			<arg path="build-cs"/>
+			<arg value="--ignore-platform-reqs"/>
 			<arg value="--ansi"/>
 		</exec>
 		<exec

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="PHPStan PHPDoc Parser">
+	<config name="php_version" value="70100"/>
 	<rule ref="build-cs/vendor/consistence/coding-standard/Consistence/ruleset.xml">
 		<exclude name="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat"/>
 		<exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
@@ -20,22 +21,11 @@
 			<property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
 		</properties>
 	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-		<properties>
-			<property name="enableObjectTypeHint" value="false"/>
-		</properties>
-		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
-	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-		<properties>
-			<property name="enableObjectTypeHint" value="false"/>
-		</properties>
 		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-		<properties>
-			<property name="enableObjectTypeHint" value="false"/>
-		</properties>
 		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,19 +20,26 @@
 			<property name="newlinesCountBetweenOpenTagAndDeclare" value="0"/>
 		</properties>
 	</rule>
-	<rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
 		<properties>
-			<property name="usefulAnnotations" type="array" value="
-				@dataProvider,
-				@requires
-			"/>
 			<property name="enableObjectTypeHint" value="false"/>
 		</properties>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification"/>
-		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
+		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+		<properties>
+			<property name="enableObjectTypeHint" value="false"/>
+		</properties>
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+		<properties>
+			<property name="enableObjectTypeHint" value="false"/>
+		</properties>
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
-	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowEqualOperators"/>
+	<rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>

--- a/src/Parser/ConstExprParser.php
+++ b/src/Parser/ConstExprParser.php
@@ -14,13 +14,15 @@ class ConstExprParser
 			$value = $tokens->currentTokenValue();
 			$tokens->next();
 			return new Ast\ConstExpr\ConstExprFloatNode($value);
+		}
 
-		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_INTEGER)) {
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_INTEGER)) {
 			$value = $tokens->currentTokenValue();
 			$tokens->next();
 			return new Ast\ConstExpr\ConstExprIntegerNode($value);
+		}
 
-		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_SINGLE_QUOTED_STRING)) {
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_SINGLE_QUOTED_STRING)) {
 			$value = $tokens->currentTokenValue();
 			if ($trimStrings) {
 				$value = trim($tokens->currentTokenValue(), "'");

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -47,7 +47,9 @@ class TypeParser
 			}
 
 			return $type;
-		} elseif ($tokens->tryConsumeTokenType(Lexer::TOKEN_THIS_VARIABLE)) {
+		}
+
+		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_THIS_VARIABLE)) {
 			$type = new Ast\Type\ThisTypeNode();
 
 			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {


### PR DESCRIPTION
See https://github.com/consistence/coding-standard/pull/65

