### PR TITLE
Support for type alias tags

### DIFF
--- a/src/Ast/PhpDoc/PhpDocNode.php
+++ b/src/Ast/PhpDoc/PhpDocNode.php
@@ -238,6 +238,20 @@ class PhpDocNode implements Node
 	}
 
 
+	/**
+	 * @return TypeAliasTagValueNode[]
+	 */
+	public function getTypeAliasTagValues(string $tagName = '@phpstan-type'): array
+	{
+		return array_column(
+			array_filter($this->getTagsByName($tagName), static function (PhpDocTagNode $tag): bool {
+				return $tag->value instanceof TypeAliasTagValueNode;
+			}),
+			'value'
+		);
+	}
+
+
 	public function __toString(): string
 	{
 		return "/**\n * " . implode("\n * ", $this->children) . '*/';

--- a/src/Ast/PhpDoc/PhpDocNode.php
+++ b/src/Ast/PhpDoc/PhpDocNode.php
@@ -252,6 +252,20 @@ class PhpDocNode implements Node
 	}
 
 
+	/**
+	 * @return TypeAliasImportTagValueNode[]
+	 */
+	public function getTypeAliasImportTagValues(string $tagName = '@phpstan-import-type'): array
+	{
+		return array_column(
+			array_filter($this->getTagsByName($tagName), static function (PhpDocTagNode $tag): bool {
+				return $tag->value instanceof TypeAliasImportTagValueNode;
+			}),
+			'value'
+		);
+	}
+
+
 	public function __toString(): string
 	{
 		return "/**\n * " . implode("\n * ", $this->children) . '*/';

--- a/src/Ast/PhpDoc/TypeAliasImportTagValueNode.php
+++ b/src/Ast/PhpDoc/TypeAliasImportTagValueNode.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\PhpDoc;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+
+class TypeAliasImportTagValueNode implements PhpDocTagValueNode
+{
+
+	/** @var string */
+	public $importedAlias;
+
+	/** @var IdentifierTypeNode */
+	public $importedFrom;
+
+	/** @var string|null */
+	public $importedAs;
+
+	public function __construct(string $importedAlias, IdentifierTypeNode $importedFrom, ?string $importedAs)
+	{
+		$this->importedAlias = $importedAlias;
+		$this->importedFrom = $importedFrom;
+		$this->importedAs = $importedAs;
+	}
+
+	public function __toString(): string
+	{
+		return trim(
+			"{$this->importedAlias} from {$this->importedFrom}"
+			. ($this->importedAs !== null ? " as {$this->importedAs}" : '')
+		);
+	}
+
+}

--- a/src/Ast/PhpDoc/TypeAliasTagValueNode.php
+++ b/src/Ast/PhpDoc/TypeAliasTagValueNode.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\PhpDoc;
+
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+
+class TypeAliasTagValueNode implements PhpDocTagValueNode
+{
+
+	/** @var string */
+	public $alias;
+
+	/** @var TypeNode */
+	public $type;
+
+	public function __construct(string $alias, TypeNode $type)
+	{
+		$this->alias = $alias;
+		$this->type = $type;
+	}
+
+
+	public function __toString(): string
+	{
+		return trim("{$this->alias} {$this->type}");
+	}
+
+}

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -189,6 +189,11 @@ class PhpDocParser
 					$tagValue = $this->parseExtendsTagValue('@use', $tokens);
 					break;
 
+				case '@phpstan-type':
+				case '@psalm-type':
+					$tagValue = $this->parseTypeAliasTagValue($tokens);
+					break;
+
 				default:
 					$tagValue = new Ast\PhpDoc\GenericTagValueNode($this->parseOptionalDescription($tokens));
 					break;
@@ -362,6 +367,19 @@ class PhpDocParser
 		}
 
 		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	private function parseTypeAliasTagValue(TokenIterator $tokens): Ast\PhpDoc\TypeAliasTagValueNode
+	{
+		$alias = $tokens->currentTokenValue();
+		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
+
+		// support psalm-type syntax
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL);
+
+		$type = $this->typeParser->parse($tokens);
+
+		return new Ast\PhpDoc\TypeAliasTagValueNode($alias, $type);
 	}
 
 	private function parseOptionalVariableName(TokenIterator $tokens): string

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -23,6 +23,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasImportTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\UsesTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
@@ -68,6 +69,7 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	 * @dataProvider provideTemplateTagsData
 	 * @dataProvider provideExtendsTagsData
 	 * @dataProvider provideTypeAliasTagsData
+	 * @dataProvider provideTypeAliasImportTagsData
 	 * @dataProvider provideRealWorldExampleData
 	 * @dataProvider provideDescriptionWithOrWithoutHtml
 	 * @param string     $label
@@ -2904,7 +2906,7 @@ some text in the middle'
 					'@phpstan-type',
 					new InvalidTagValueNode(
 						'TypeAlias',
-						new ParserException(
+						new \PHPStan\PhpDocParser\Parser\ParserException(
 							'*/',
 							Lexer::TOKEN_CLOSE_PHPDOC,
 							28,
@@ -2923,10 +2925,100 @@ some text in the middle'
 					'@phpstan-type',
 					new InvalidTagValueNode(
 						'',
-						new ParserException(
+						new \PHPStan\PhpDocParser\Parser\ParserException(
 							'*/',
 							Lexer::TOKEN_CLOSE_PHPDOC,
 							18,
+							Lexer::TOKEN_IDENTIFIER
+						)
+					)
+				),
+			]),
+		];
+	}
+
+	public function provideTypeAliasImportTagsData(): \Iterator
+	{
+		yield [
+			'OK',
+			'/** @phpstan-import-type TypeAlias from AnotherClass */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new TypeAliasImportTagValueNode(
+						'TypeAlias',
+						new IdentifierTypeNode('AnotherClass'),
+						null
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with alias',
+			'/** @phpstan-import-type TypeAlias from AnotherClass as DifferentAlias */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new TypeAliasImportTagValueNode(
+						'TypeAlias',
+						new IdentifierTypeNode('AnotherClass'),
+						'DifferentAlias'
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid missing from',
+			'/** @phpstan-import-type TypeAlias */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new InvalidTagValueNode(
+						'TypeAlias',
+						new \PHPStan\PhpDocParser\Parser\ParserException(
+							'*/',
+							Lexer::TOKEN_CLOSE_PHPDOC,
+							35,
+							Lexer::TOKEN_IDENTIFIER
+						)
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid missing from with alias',
+			'/** @phpstan-import-type TypeAlias as DifferentAlias */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new InvalidTagValueNode(
+						'TypeAlias as DifferentAlias',
+						new \PHPStan\PhpDocParser\Parser\ParserException(
+							'as',
+							Lexer::TOKEN_IDENTIFIER,
+							35,
+							Lexer::TOKEN_IDENTIFIER
+						)
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid empty',
+			'/** @phpstan-import-type */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new InvalidTagValueNode(
+						'',
+						new \PHPStan\PhpDocParser\Parser\ParserException(
+							'*/',
+							Lexer::TOKEN_CLOSE_PHPDOC,
+							25,
 							Lexer::TOKEN_IDENTIFIER
 						)
 					)

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -23,6 +23,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\UsesTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
@@ -66,6 +67,7 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 	 * @dataProvider provideMultiLinePhpDocData
 	 * @dataProvider provideTemplateTagsData
 	 * @dataProvider provideExtendsTagsData
+	 * @dataProvider provideTypeAliasTagsData
 	 * @dataProvider provideRealWorldExampleData
 	 * @dataProvider provideDescriptionWithOrWithoutHtml
 	 * @param string     $label
@@ -2852,6 +2854,81 @@ some text in the middle'
 						false,
 						'$test',
 						'some description'
+					)
+				),
+			]),
+		];
+	}
+
+	public function provideTypeAliasTagsData(): \Iterator
+	{
+		yield [
+			'OK',
+			'/** @phpstan-type TypeAlias string|int */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-type',
+					new TypeAliasTagValueNode(
+						'TypeAlias',
+						new UnionTypeNode([
+							new IdentifierTypeNode('string'),
+							new IdentifierTypeNode('int'),
+						])
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with psalm syntax',
+			'/** @psalm-type TypeAlias=string|int */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@psalm-type',
+					new TypeAliasTagValueNode(
+						'TypeAlias',
+						new UnionTypeNode([
+							new IdentifierTypeNode('string'),
+							new IdentifierTypeNode('int'),
+						])
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid without type',
+			'/** @phpstan-type TypeAlias */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-type',
+					new InvalidTagValueNode(
+						'TypeAlias',
+						new ParserException(
+							'*/',
+							Lexer::TOKEN_CLOSE_PHPDOC,
+							28,
+							Lexer::TOKEN_IDENTIFIER
+						)
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid empty',
+			'/** @phpstan-type */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-type',
+					new InvalidTagValueNode(
+						'',
+						new ParserException(
+							'*/',
+							Lexer::TOKEN_CLOSE_PHPDOC,
+							18,
+							Lexer::TOKEN_IDENTIFIER
+						)
 					)
 				),
 			]),


### PR DESCRIPTION
This PR adds support for [`@psalm-type`](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-type) and [`@psalm-import-type`](https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-import-type) as well as `@phpstan-` prefixed alternatives:

```php
/**
 * @phpstan-type TypeAlias callable(string): bool
 */
class Foo {}

/**
 * @phpstan-import-type TypeAlias from Foo as ImportedAlias
 */
class Bar {}
```