### PR TITLE
Fix PhpDocNode end newline print

### DIFF
--- a/src/Ast/PhpDoc/PhpDocNode.php
+++ b/src/Ast/PhpDoc/PhpDocNode.php
@@ -271,7 +271,7 @@ class PhpDocNode implements Node
 
 	public function __toString(): string
 	{
-		return "/**\n * " . implode("\n * ", $this->children) . '*/';
+		return "/**\n * " . implode("\n * ", $this->children) . "\n */";
 	}
 
 }

--- a/tests/PHPStan/Ast/PhpDoc/NodePrintTest.php
+++ b/tests/PHPStan/Ast/PhpDoc/NodePrintTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\PhpDoc;
+
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPUnit\Framework\TestCase;
+
+final class NodePrintTest extends TestCase
+{
+
+	/**
+	 * @dataProvider providePhpDocData
+	 */
+	public function testPrintMultiline(Node $node, string $expectedPrinted): void
+	{
+		$this->assertSame($expectedPrinted, (string) $node);
+	}
+
+
+	public function providePhpDocData(): \Iterator
+	{
+		yield [
+			new PhpDocNode([
+				new PhpDocTextNode('It works'),
+			]),
+			'/**
+ * It works
+ */',
+		];
+	}
+
+}


### PR DESCRIPTION
This has to be worked around on every `PhpDocNode` in Rector: https://github.com/rectorphp/rector/blob/57acbe7cdca1bb73e155920c5f9596bd5f10e2b6/packages/AttributeAwarePhpDoc/Ast/PhpDoc/AttributeAwarePhpDocNode.php#L22

This should fix it here:

## Before 

```php
/**
 * @var int*/
```

## After

```php
/**
 * @var int
 */
```