### PR TITLE
type aliases: more defensive parsing of type alias import targets

### DIFF
--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -403,8 +403,8 @@ class PhpDocParser
 			);
 		}
 
-		$importedFrom = $this->typeParser->parse($tokens);
-		assert($importedFrom instanceof IdentifierTypeNode);
+		$importedFrom = $tokens->currentTokenValue();
+		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
 		$importedAs = null;
 		if ($tokens->tryConsumeTokenValue('as')) {
@@ -412,7 +412,7 @@ class PhpDocParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 		}
 
-		return new Ast\PhpDoc\TypeAliasImportTagValueNode($importedAlias, $importedFrom, $importedAs);
+		return new Ast\PhpDoc\TypeAliasImportTagValueNode($importedAlias, new IdentifierTypeNode($importedFrom), $importedAs);
 	}
 
 	private function parseOptionalVariableName(TokenIterator $tokens): string

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -2989,6 +2989,44 @@ some text in the middle'
 		];
 
 		yield [
+			'invalid non-identifier from',
+			'/** @phpstan-import-type TypeAlias from 42 */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new InvalidTagValueNode(
+						'TypeAlias from 42',
+						new \PHPStan\PhpDocParser\Parser\ParserException(
+							'42',
+							Lexer::TOKEN_INTEGER,
+							40,
+							Lexer::TOKEN_IDENTIFIER
+						)
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid non-simple-identifier from',
+			'/** @phpstan-import-type TypeAlias from AnotherClass[] */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-import-type',
+					new InvalidTagValueNode(
+						'Unexpected token "[", expected \'*/\' at offset 52',
+						new \PHPStan\PhpDocParser\Parser\ParserException(
+							'[',
+							Lexer::TOKEN_OPEN_SQUARE_BRACKET,
+							52,
+							Lexer::TOKEN_CLOSE_PHPDOC
+						)
+					)
+				),
+			]),
+		];
+
+		yield [
 			'invalid missing from',
 			'/** @phpstan-import-type TypeAlias */',
 			new PhpDocNode([


### PR DESCRIPTION
This makes sure that `$importedFrom` is always actually `IdentifierTypeNode`, and catches the most obvious unsupported types such as

```php
/**
 * @phpstan-import-type Foo from 42
 * @phpstan-import-type Foo from ArraysAreNotSupported[]
 * @phpstan-import-type Foo from NeitherAreGenerics<string>
 */
```

It has been suggested (https://github.com/phpstan/phpstan/issues/3001#issuecomment-754272815) that local aliases could somehow support generics. As far as I am concerned, that's still far in the future and will need some careful consideration, so I'm proposing to restrict it now as well, and perhaps revisit it later once it's more clear how generic aliases should work.