### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,15 @@
 *.abnf text eol=crlf
 
 /tests export-ignore
+/doc/grammars export-ignore
+/build-cs export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.travis.yml export-ignore
+.editorconfig export-ignore
+.github export-ignore
 build.xml export-ignore
 phpcs.xml export-ignore
+build.xml export-ignore
+phpstan.neon export-ignore
+build-abnfgen.sh export-ignore
+CODE_OF_CONDUCT.md export-ignore


### PR DESCRIPTION
Fixes: #71 

To test: `git archive HEAD --format zip --output=repo.zip`

Before: `41,0 KiB (42 028 octets)`
After: `31,7 KiB (32 488 octets)`