### PR TITLE
Fix wildcard parsing to end if a space follows

### DIFF
--- a/src/Parser/ConstExprParser.php
+++ b/src/Parser/ConstExprParser.php
@@ -70,6 +70,10 @@ class ConstExprParser
 						$classConstantName .= '*';
 						$lastType = Lexer::TOKEN_WILDCARD;
 
+						if ($tokens->getSkippedHorizontalWhiteSpaceIfAny() !== '') {
+							break;
+						}
+
 						continue;
 					}
 

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -155,6 +155,22 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 		];
 
 		yield [
+			'OK const wildcard with description',
+			'/** @param self::* $foo optional description */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@param',
+					new ParamTagValueNode(
+						new ConstTypeNode(new ConstFetchNode('self', '*')),
+						false,
+						'$foo',
+						'optional description'
+					)
+				),
+			]),
+		];
+
+		yield [
 			'invalid without type, parameter name and description',
 			'/** @param */',
 			new PhpDocNode([
@@ -502,6 +518,21 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 						new IdentifierTypeNode('Foo'),
 						'$foo',
 						'#desc'
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with variable name and description and const expression',
+			'/** @var self::* $foo optional description */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@var',
+					new VarTagValueNode(
+						new ConstTypeNode(new ConstFetchNode('self', '*')),
+						'$foo',
+						'optional description'
 					)
 				),
 			]),
@@ -1003,6 +1034,20 @@ class PhpDocParserTest extends \PHPUnit\Framework\TestCase
 							),
 						]),
 						''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with constant wildcard and description',
+			'/** @return self::* example description */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new ConstTypeNode(new ConstFetchNode('self', '*')),
+						'example description'
 					)
 				),
 			]),


### PR DESCRIPTION
Fixes phpstan/phpstan#5628

I believe this is correct.. as soon as a whitespace was skipped after a `*`, it means the `x::*` or `x::foo*` or `x::*foo*` expression ended and we should stop consuming right away.

I think it was only a problem with `@return` because there is no $var there so it is followed by a TOKEN_IDENTIFIER there, instead of TOKEN_VARIABLE in the others. Anyway the fix should be applicable to all circumstances if I am not mistaken :)