### PR TITLE
TypeParser - Handle union on nullable

### DIFF
--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -162,15 +162,20 @@ class TypeParser
 		$type = new Ast\Type\IdentifierTypeNode($tokens->currentTokenValue());
 		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
-		if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
-			$type = $this->parseGeneric($tokens, $type);
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_UNION)) {
+			$type = $this->parseUnion($tokens, $type);
 
-		} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
-			$type = $this->parseArrayShape($tokens, $type);
-		}
+		} else {
+			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
+				$type = $this->parseGeneric($tokens, $type);
 
-		if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
-			$type = $this->tryParseArray($tokens, $type);
+			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
+				$type = $this->parseArrayShape($tokens, $type);
+			}
+
+			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
+				$type = $this->tryParseArray($tokens, $type);
+			}
 		}
 
 		return new Ast\Type\NullableTypeNode($type);

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -257,6 +257,15 @@ class TypeParserTest extends \PHPUnit\Framework\TestCase
 				),
 			],
 			[
+				'?string|int',
+				new NullableTypeNode(
+					new UnionTypeNode([
+						new IdentifierTypeNode('string'),
+						new IdentifierTypeNode('int'),
+					])
+				),
+			],
+			[
 				'?Foo<Bar>',
 				new NullableTypeNode(
 					new GenericTypeNode(


### PR DESCRIPTION
I was working on https://github.com/symfony/symfony/pull/40457 to introduce this parser as the default extractor for Symfony. And one of the actual tests (https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php#L86-L89) contains a PhpDoc with `@var ?string|int`.
And the only remaining issue I have on this extractor is that PhpStan can't parse correctly nullable union types !

Here is the output with the latest version of `phpstan/phpdoc-parser`:
```php
^ PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode^ {#358
  +children: array:1 [
    0 => PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode^ {#316
      +name: "@var"
      +value: PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode^ {#399
        +value: "?string|int"
        +exception: PHPStan\PhpDocParser\Parser\ParserException^ {#398
          -currentTokenValue: "|"
          -currentTokenType: 1
          -currentOffset: 23
          -expectedTokenType: 27
          #message: "Unexpected token "|", expected TOKEN_OTHER at offset 23"
          #code: 0
          #file: "./vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php"
          #line: 183
          trace: {
            ./vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:183 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/TokenIterator.php:80 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:438 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:220 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:113 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:92 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:53 { …}
            ./vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php:38 { …}
            ./src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php:233 {
              Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor->getDocBlockFromProperty(string $class, string $property): PhpDocNode^
              › $tokens = new TokenIterator($this->lexer->tokenize($rawDocNode));
              › $phpDocNode = $this->phpDocParser->parse($tokens);
              › dd($phpDocNode);
            }
            ./src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php:199 { …}
            ./src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php:73 { …}
            ./src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php:184 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestCase.php:1528 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestCase.php:1134 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestResult.php:722 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestCase.php:886 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestSuite.php:678 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestSuite.php:678 { …}
            ./.phpunit/phpunit-9.5-0/src/Framework/TestSuite.php:678 { …}
            ./.phpunit/phpunit-9.5-0/src/TextUI/TestRunner.php:670 { …}
            ./.phpunit/phpunit-9.5-0/src/TextUI/Command.php:143 { …}
            ./.phpunit/phpunit-9.5-0/src/TextUI/Command.php:96 { …}
            ./.phpunit/phpunit-9.5-0/phpunit:22 { …}
            ./vendor/symfony/phpunit-bridge/bin/simple-phpunit.php:430 { …}
            ./vendor/symfony/phpunit-bridge/bin/simple-phpunit:13 { …}
            ./phpunit:28 { …}
          }
        }
      }
    }
  ]
}
```

So this PR introduce a fix to make this parser work correctly with nullable union types