### PR TITLE
Properly handle string literals with spaces

### DIFF
--- a/src/Ast/ConstExpr/ConstExprStringNode.php
+++ b/src/Ast/ConstExpr/ConstExprStringNode.php
@@ -14,13 +14,26 @@ class ConstExprStringNode implements ConstExprNode
 
 	public function __construct(string $value)
 	{
+		$len = strlen($value);
+		if ($len >= 2 && (
+			($value[0] === '"' && $value[$len-1] === '"')
+			|| ($value[0] === "'" && $value[$len-1] === "'")
+		)) {
+			$value = substr($value, 1, -1);
+		}
+		// Don't go crazy with escaping
+		if (strpos($value, '"') !== false) {
+			$value = "'".$value."'";
+		} else {
+			$value = '"'.$value.'"';
+		}
 		$this->value = $value;
 	}
 
 
 	public function __toString(): string
 	{
-		return '"'.$this->value.'"';
+		return $this->value;
 	}
 
 }

--- a/src/Ast/ConstExpr/ConstExprStringNode.php
+++ b/src/Ast/ConstExpr/ConstExprStringNode.php
@@ -20,7 +20,7 @@ class ConstExprStringNode implements ConstExprNode
 
 	public function __toString(): string
 	{
-		return $this->value;
+		return '"'.$this->value.'"';
 	}
 
 }

--- a/src/Ast/ConstExpr/ConstExprStringNode.php
+++ b/src/Ast/ConstExpr/ConstExprStringNode.php
@@ -3,9 +3,6 @@
 namespace PHPStan\PhpDocParser\Ast\ConstExpr;
 
 use PHPStan\PhpDocParser\Ast\NodeAttributes;
-use function strlen;
-use function strpos;
-use function substr;
 
 class ConstExprStringNode implements ConstExprNode
 {

--- a/src/Ast/ConstExpr/ConstExprStringNode.php
+++ b/src/Ast/ConstExpr/ConstExprStringNode.php
@@ -3,6 +3,9 @@
 namespace PHPStan\PhpDocParser\Ast\ConstExpr;
 
 use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use function strlen;
+use function strpos;
+use function substr;
 
 class ConstExprStringNode implements ConstExprNode
 {
@@ -16,16 +19,16 @@ class ConstExprStringNode implements ConstExprNode
 	{
 		$len = strlen($value);
 		if ($len >= 2 && (
-			($value[0] === '"' && $value[$len-1] === '"')
-			|| ($value[0] === "'" && $value[$len-1] === "'")
+			($value[0] === '"' && $value[$len - 1] === '"')
+			|| ($value[0] === "'" && $value[$len - 1] === "'")
 		)) {
 			$value = substr($value, 1, -1);
 		}
 		// Don't go crazy with escaping
 		if (strpos($value, '"') !== false) {
-			$value = "'".$value."'";
+			$value = "'" . $value . "'";
 		} else {
-			$value = '"'.$value.'"';
+			$value = '"' . $value . '"';
 		}
 		$this->value = $value;
 	}

--- a/src/Ast/ConstExpr/ConstExprStringNode.php
+++ b/src/Ast/ConstExpr/ConstExprStringNode.php
@@ -17,19 +17,6 @@ class ConstExprStringNode implements ConstExprNode
 
 	public function __construct(string $value)
 	{
-		$len = strlen($value);
-		if ($len >= 2 && (
-			($value[0] === '"' && $value[$len - 1] === '"')
-			|| ($value[0] === "'" && $value[$len - 1] === "'")
-		)) {
-			$value = substr($value, 1, -1);
-		}
-		// Don't go crazy with escaping
-		if (strpos($value, '"') !== false) {
-			$value = "'" . $value . "'";
-		} else {
-			$value = '"' . $value . '"';
-		}
 		$this->value = $value;
 	}
 

--- a/src/Ast/PhpDoc/DeprecatedTagValueNode.php
+++ b/src/Ast/PhpDoc/DeprecatedTagValueNode.php
@@ -3,6 +3,8 @@
 namespace PHPStan\PhpDocParser\Ast\PhpDoc;
 
 use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use function explode;
+use function implode;
 use function trim;
 
 class DeprecatedTagValueNode implements PhpDocTagValueNode
@@ -21,7 +23,7 @@ class DeprecatedTagValueNode implements PhpDocTagValueNode
 
 	public function __toString(): string
 	{
-		return trim($this->description);
+		return implode("\n * ", explode("\n", trim($this->description)));
 	}
 
 }

--- a/src/Ast/PhpDoc/PhpDocTextNode.php
+++ b/src/Ast/PhpDoc/PhpDocTextNode.php
@@ -3,6 +3,8 @@
 namespace PHPStan\PhpDocParser\Ast\PhpDoc;
 
 use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use function explode;
+use function implode;
 
 class PhpDocTextNode implements PhpDocChildNode
 {
@@ -20,7 +22,7 @@ class PhpDocTextNode implements PhpDocChildNode
 
 	public function __toString(): string
 	{
-		return $this->text;
+		return implode("\n * ", explode("\n", $this->text));
 	}
 
 }

--- a/src/Ast/Type/CallableTypeParameterNode.php
+++ b/src/Ast/Type/CallableTypeParameterNode.php
@@ -40,7 +40,7 @@ class CallableTypeParameterNode implements Node
 		$type = "{$this->type} ";
 		$isReference = $this->isReference ? '&' : '';
 		$isVariadic = $this->isVariadic ? '...' : '';
-		$default = $this->isOptional ? ' = default' : '';
+		$default = $this->isOptional ? ' = ' : '';
 		return "{$type}{$isReference}{$isVariadic}{$this->parameterName}{$default}";
 	}
 

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -119,7 +119,7 @@ class TypeParser
 		}
 
 		try {
-			$constExpr = $this->constExprParser->parse($tokens, true);
+			$constExpr = $this->constExprParser->parse($tokens);
 			if ($constExpr instanceof Ast\ConstExpr\ConstExprArrayNode) {
 				throw $exception;
 			}

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -405,11 +405,11 @@ class TypeParser
 			$tokens->next();
 
 		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_SINGLE_QUOTED_STRING)) {
-			$key = new Ast\ConstExpr\ConstExprStringNode(trim($tokens->currentTokenValue(), "'"));
+			$key = new Ast\ConstExpr\ConstExprStringNode($tokens->currentTokenValue());
 			$tokens->next();
 
 		} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_DOUBLE_QUOTED_STRING)) {
-			$key = new Ast\ConstExpr\ConstExprStringNode(trim($tokens->currentTokenValue(), '"'));
+			$key = new Ast\ConstExpr\ConstExprStringNode($tokens->currentTokenValue());
 			$tokens->next();
 
 		} else {

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -6,7 +6,6 @@ use LogicException;
 use PHPStan\PhpDocParser\Ast;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use function strpos;
-use function trim;
 
 class TypeParser
 {

--- a/tests/PHPStan/Parser/ConstExprParserTest.php
+++ b/tests/PHPStan/Parser/ConstExprParserTest.php
@@ -51,6 +51,13 @@ class ConstExprParserTest extends TestCase
 		$this->assertSame((string) $expectedExpr, (string) $exprNode);
 		$this->assertEquals($expectedExpr, $exprNode);
 		$this->assertSame($nextTokenType, $tokens->currentTokenType());
+
+		$tokens = new TokenIterator($this->lexer->tokenize((string) $exprNode));
+		$exprNode = $this->constExprParser->parse($tokens);
+
+		$this->assertSame((string) $expectedExpr, (string) $exprNode);
+		$this->assertEquals($expectedExpr, $exprNode);
+		$this->assertSame($nextTokenType, $tokens->currentTokenType());
 	}
 
 
@@ -214,6 +221,11 @@ class ConstExprParserTest extends TestCase
 		yield [
 			'"foo"',
 			new ConstExprStringNode('"foo"'),
+		];
+
+		yield [
+			'"foo bar"',
+			new ConstExprStringNode('"foo bar"'),
 		];
 
 		yield [

--- a/tests/PHPStan/Parser/ConstExprParserTest.php
+++ b/tests/PHPStan/Parser/ConstExprParserTest.php
@@ -229,6 +229,11 @@ class ConstExprParserTest extends TestCase
 		];
 
 		yield [
+			'"foo \' bar"',
+			new ConstExprStringNode('"foo \' bar"'),
+		];
+
+		yield [
 			'"Foo \\n\\"\\r Bar"',
 			new ConstExprStringNode('"Foo \\n\\"\\r Bar"'),
 		];

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -28,6 +28,8 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasImportTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\UsesTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeParameterNode;
@@ -99,6 +101,28 @@ class PhpDocParserTest extends TestCase
 						new IdentifierTypeNode('Foo'),
 						false,
 						'$foo',
+						''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK',
+			'/** @return array{name: "A B C"} */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new ArrayShapeNode([
+							new ArrayShapeItemNode(
+								new IdentifierTypeNode('name'),
+								false,
+								new ConstTypeNode(
+									new ConstExprStringNode('"A B C"')
+								)
+							),
+						]),
 						''
 					)
 				),

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -39,6 +39,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPUnit\Framework\TestCase;
+use function strpos;
 use const PHP_EOL;
 
 class PhpDocParserTest extends TestCase

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -3426,8 +3426,8 @@ Finder::findFiles('*.php')
 					'@return',
 					new ReturnTagValueNode(
 						new UnionTypeNode([
-							new ConstTypeNode(new ConstExprStringNode('foo')),
-							new ConstTypeNode(new ConstExprStringNode('bar')),
+							new ConstTypeNode(new ConstExprStringNode("'foo'")),
+							new ConstTypeNode(new ConstExprStringNode("'bar'")),
 						]),
 						''
 					)

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -118,15 +118,15 @@ class PhpDocParserTest extends TestCase
 		];
 
 		yield [
-			'OK',
-			'/** @return array{name: "A B C"} */',
+			'OK spaces in shapes',
+			'/** @return array{"name 1 2 3": "A B C"} */',
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@return',
 					new ReturnTagValueNode(
 						new ArrayShapeNode([
 							new ArrayShapeItemNode(
-								new IdentifierTypeNode('name'),
+								new ConstExprStringNode('"name 1 2 3"'),
 								false,
 								new ConstTypeNode(
 									new ConstExprStringNode('"A B C"')

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -86,6 +86,16 @@ class PhpDocParserTest extends TestCase
 		$this->assertEquals($expectedPhpDocNode, $actualPhpDocNode, $label);
 		$this->assertSame((string) $expectedPhpDocNode, (string) $actualPhpDocNode);
 		$this->assertSame($nextTokenType, $tokens->currentTokenType());
+
+		if (strpos($label, 'OK') !== 0) {
+			return;
+		}
+		$tokens = new TokenIterator($this->lexer->tokenize((string) $actualPhpDocNode));
+		$actualPhpDocNode = $this->phpDocParser->parse($tokens);
+
+		$this->assertEquals($expectedPhpDocNode, $actualPhpDocNode, $label);
+		$this->assertSame((string) $expectedPhpDocNode, (string) $actualPhpDocNode);
+		$this->assertSame($nextTokenType, $tokens->currentTokenType());
 	}
 
 

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -470,7 +470,7 @@ class TypeParserTest extends TestCase
 				'array{"a": int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('a'),
+						new ConstExprStringNode('"a"'),
 						false,
 						new IdentifierTypeNode('int')
 					),
@@ -480,7 +480,7 @@ class TypeParserTest extends TestCase
 				'array{\'a\': int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('a'),
+						new ConstExprStringNode("'a'"),
 						false,
 						new IdentifierTypeNode('int')
 					),
@@ -490,7 +490,7 @@ class TypeParserTest extends TestCase
 				'array{\'$ref\': int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('$ref'),
+						new ConstExprStringNode("'\$ref'"),
 						false,
 						new IdentifierTypeNode('int')
 					),
@@ -500,7 +500,7 @@ class TypeParserTest extends TestCase
 				'array{"$ref": int}',
 				new ArrayShapeNode([
 					new ArrayShapeItemNode(
-						new ConstExprStringNode('$ref'),
+						new ConstExprStringNode('"$ref"'),
 						false,
 						new IdentifierTypeNode('int')
 					),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -836,8 +836,8 @@ class TypeParserTest extends TestCase
 			[
 				"'foo'|'bar'",
 				new UnionTypeNode([
-					new ConstTypeNode(new ConstExprStringNode('foo')),
-					new ConstTypeNode(new ConstExprStringNode('bar')),
+					new ConstTypeNode(new ConstExprStringNode("'foo'")),
+					new ConstTypeNode(new ConstExprStringNode("'bar'")),
 				]),
 			],
 			[
@@ -854,7 +854,7 @@ class TypeParserTest extends TestCase
 			],
 			[
 				'"bar"',
-				new ConstTypeNode(new ConstExprStringNode('bar')),
+				new ConstTypeNode(new ConstExprStringNode('"bar"')),
 			],
 			[
 				'Foo::FOO_*',
@@ -892,7 +892,7 @@ class TypeParserTest extends TestCase
 			[
 				'( "foo" | Foo::FOO_* )',
 				new UnionTypeNode([
-					new ConstTypeNode(new ConstExprStringNode('foo')),
+					new ConstTypeNode(new ConstExprStringNode('"foo"')),
 					new ConstTypeNode(new ConstFetchNode('Foo', 'FOO_*')),
 				]),
 			],

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -60,6 +60,18 @@ class TypeParserTest extends TestCase
 		$this->assertInstanceOf(get_class($expectedResult), $typeNode);
 		$this->assertEquals($expectedResult, $typeNode);
 		$this->assertSame($nextTokenType, $tokens->currentTokenType());
+
+		if ($nextTokenType !== Lexer::TOKEN_END) {
+			return;
+		}
+
+		$tokens = new TokenIterator($this->lexer->tokenize((string) $typeNode));
+		$typeNode = $this->typeParser->parse($tokens);
+
+		$this->assertSame((string) $expectedResult, (string) $typeNode);
+		$this->assertInstanceOf(get_class($expectedResult), $typeNode);
+		$this->assertEquals($expectedResult, $typeNode);
+		$this->assertSame($nextTokenType, $tokens->currentTokenType());
 	}
 
 


### PR DESCRIPTION
Encountered broken phpdocs after running php-cbf with the Slevomat coding standard due to spaces in some literal strings, this should fix the issue.