### PR TITLE
Extend allowed types for conditional for parameter

### DIFF
--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -259,15 +259,19 @@ class TypeParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 		}
 
-		$targetType = $this->parseAtomic($tokens);
+		$targetType = $this->parse($tokens);
 
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_NULLABLE);
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 
-		$ifType = $this->parseAtomic($tokens);
+		$ifType = $this->parse($tokens);
 
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_COLON);
+		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 
-		$elseType = $this->parseAtomic($tokens);
+		$elseType = $this->parse($tokens);
 
 		return new Ast\Type\ConditionalTypeForParameterNode($parameterName, $targetType, $ifType, $elseType, $negated);
 	}

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -1231,7 +1231,7 @@ class TypeParserTest extends TestCase
 				'(' . PHP_EOL .
 				'  $foo is Bar|Baz' . PHP_EOL .
 				'    ? never' . PHP_EOL .
-		        '    : int|string' . PHP_EOL .
+				'    : int|string' . PHP_EOL .
 				')',
 				new ConditionalTypeForParameterNode(
 					'$foo',

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeParameterNode;
+use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeForParameterNode;
 use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
@@ -1207,6 +1208,42 @@ class TypeParserTest extends TestCase
 						]),
 						false
 					),
+					false
+				),
+			],
+			[
+				'($foo is Bar|Baz ? never : int|string)',
+				new ConditionalTypeForParameterNode(
+					'$foo',
+					new UnionTypeNode([
+						new IdentifierTypeNode('Bar'),
+						new IdentifierTypeNode('Baz'),
+					]),
+					new IdentifierTypeNode('never'),
+					new UnionTypeNode([
+						new IdentifierTypeNode('int'),
+						new IdentifierTypeNode('string'),
+					]),
+					false
+				),
+			],
+			[
+				'(' . PHP_EOL .
+				'  $foo is Bar|Baz' . PHP_EOL .
+				'    ? never' . PHP_EOL .
+		        '    : int|string' . PHP_EOL .
+				')',
+				new ConditionalTypeForParameterNode(
+					'$foo',
+					new UnionTypeNode([
+						new IdentifierTypeNode('Bar'),
+						new IdentifierTypeNode('Baz'),
+					]),
+					new IdentifierTypeNode('never'),
+					new UnionTypeNode([
+						new IdentifierTypeNode('int'),
+						new IdentifierTypeNode('string'),
+					]),
 					false
 				),
 			],


### PR DESCRIPTION
Conditional allows more whitespace between operators and union types, but this was omitted for conditional for parameter