### PR TITLE
Implement offset access type syntax

### DIFF
--- a/src/Ast/Type/OffsetAccessTypeNode.php
+++ b/src/Ast/Type/OffsetAccessTypeNode.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\Type;
+
+use PHPStan\PhpDocParser\Ast\NodeAttributes;
+
+class OffsetAccessTypeNode implements TypeNode
+{
+
+	use NodeAttributes;
+
+	/** @var TypeNode */
+	public $type;
+
+	/** @var TypeNode */
+	public $offset;
+
+	public function __construct(TypeNode $type, TypeNode $offset)
+	{
+		$this->type = $type;
+		$this->offset = $offset;
+	}
+
+	public function __toString(): string
+	{
+		return $this->type . '[' . $this->offset . ']';
+	}
+
+}

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -36,6 +36,7 @@ use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPUnit\Framework\TestCase;
@@ -967,6 +968,23 @@ class PhpDocParserTest extends TestCase
 					new ReturnTagValueNode(
 						new IdentifierTypeNode('Foo'),
 						'[Bar]'
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with offset access type',
+			'/** @return Foo[Bar] */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new OffsetAccessTypeNode(
+							new IdentifierTypeNode('Foo'),
+							new IdentifierTypeNode('Bar')
+						),
+						''
 					)
 				),
 			]),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -19,6 +19,7 @@ use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
@@ -746,6 +747,13 @@ class TypeParserTest extends TestCase
 				'array [ int ]',
 				new IdentifierTypeNode('array'),
 				Lexer::TOKEN_OPEN_SQUARE_BRACKET,
+			],
+			[
+				'array[ int ]',
+				new OffsetAccessTypeNode(
+					new IdentifierTypeNode('array'),
+					new IdentifierTypeNode('int')
+				),
 			],
 			[
 				"?\t\xA009", // edge-case with \h


### PR DESCRIPTION
This implements offset access types keeping as much BC as possible. Notably, whitespace between the type and `[` is not allowed (so `A[B]` is valid but `A [B]` parses as just `A`, as before)