### PR TITLE
Optimize Lexer::tokenize()

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -105,16 +105,11 @@ class Lexer
 		assert($this->regexp !== null);
 		assert($this->types !== null);
 
-		preg_match_all($this->regexp, $s, $tokens, PREG_SET_ORDER);
+		preg_match_all($this->regexp, $s, $matches, PREG_SET_ORDER);
 
-		$count = count($this->types);
-		foreach ($tokens as &$match) {
-			for ($i = 1; $i <= $count; $i++) {
-				if ($match[$i] !== null && $match[$i] !== '') {
-					$match = [$match[0], $this->types[$i - 1]];
-					break;
-				}
-			}
+		$tokens = [];
+		foreach ($matches as $match) {
+			$tokens[] = [$match[0], $this->types[count($match) - 2]];
 		}
 
 		$tokens[] = ['', self::TOKEN_END];


### PR DESCRIPTION
Parsing the docblock from [CarbonInterface](https://github.com/briannesbitt/Carbon/blob/4c4f99e79a9ddea9bb1458a4cca3d4c06c24beff/src/Carbon/CarbonInterface.php) 50 times takes ~3.5s before this change, and ~1s after.