### PR TITLE
Add ObjectShapeNode to support @var object{foo: string} $foo

### DIFF
--- a/src/Ast/Type/ObjectShapeItemNode.php
+++ b/src/Ast/Type/ObjectShapeItemNode.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\Type;
+
+class ObjectShapeItemNode extends ArrayShapeItemNode
+{
+}

--- a/src/Ast/Type/ObjectShapeNode.php
+++ b/src/Ast/Type/ObjectShapeNode.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\Type;
+
+use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use function implode;
+
+class ObjectShapeNode implements TypeNode
+{
+
+	use NodeAttributes;
+
+	/** @var ObjectShapeItemNode[] */
+	public $items;
+
+	public function __construct(array $items)
+	{
+		$this->items = $items;
+	}
+
+
+	public function __toString(): string
+	{
+		return 'object{' . implode(', ', $this->items) . '}';
+	}
+
+}

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -44,6 +44,8 @@ use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPUnit\Framework\TestCase;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeItemNode;
 use const PHP_EOL;
 
 class PhpDocParserTest extends TestCase
@@ -890,6 +892,69 @@ class PhpDocParserTest extends TestCase
 							44,
 							Lexer::TOKEN_CLOSE_PHPDOC
 						)
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK without variable and description object shape',
+			'/** @var object{a: int} */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@var',
+					new VarTagValueNode(
+						new ObjectShapeNode([
+							new ObjectShapeItemNode(
+								new IdentifierTypeNode('a'),
+								false,
+								new IdentifierTypeNode('int')
+							)
+							]),
+							'',
+							''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with variable object shape',
+			'/** @var object{a: int} $foo */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@var',
+					new VarTagValueNode(
+						new ObjectShapeNode([
+							new ObjectShapeItemNode(
+								new IdentifierTypeNode('a'),
+								false,
+								new IdentifierTypeNode('int')
+							)
+							]),
+							'$foo',
+							''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK with variable and description object shape',
+			'/** @var object{a: int} $foo some description */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@var',
+					new VarTagValueNode(
+						new ObjectShapeNode([
+							new ObjectShapeItemNode(
+								new IdentifierTypeNode('a'),
+								false,
+								new IdentifierTypeNode('int')
+							)
+							]),
+							'$foo',
+							'some description'
 					)
 				),
 			]),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -19,6 +19,8 @@ use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeItemNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
@@ -590,6 +592,18 @@ class TypeParserTest extends TestCase
 						false,
 						new IdentifierTypeNode('string')
 					),
+				]),
+			],
+			[
+				'object{
+				 	a: int
+				 }',
+				new ObjectShapeNode([
+					new ObjectShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					)
 				]),
 			],
 			[


### PR DESCRIPTION
The issue originally on : 

- https://github.com/rectorphp/rector/issues/7393

which has failing test at: 

- https://github.com/rectorphp/rector-src/pull/2797 

which the `VarTagValueNode` got empty variable name and the variable goes to description:

```bash
PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode #17240
   type: PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode #17247
   |  name: 'object'
   |  attributes: array (2)
   |  |  'parent' => PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode #17470 see below
   |  |  'orig_node' => PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode #17249
   |  |  |  name: 'object'
   |  |  |  attributes: array (1)
   |  |  |  |  'parent' => PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode #17470 see below
   variableName: ''
   description: '{foo: string} $foo'
```

This PR try to add support for `@var object{foo: string} $foo` usage. In PHPStan demo site itself, it detected as property $foo not exists:

https://phpstan.org/r/47583831-d7ae-43b8-bae9-bfabead3459b

while it actually exists https://3v4l.org/Vo8FA