### PR TITLE
Allow backslash in PHPDoc tag

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -146,7 +146,7 @@ class Lexer
 
 			self::TOKEN_OPEN_PHPDOC => '/\\*\\*(?=\\s)\\x20?+',
 			self::TOKEN_CLOSE_PHPDOC => '\\*/',
-			self::TOKEN_PHPDOC_TAG => '@[a-z][a-z0-9-]*+',
+			self::TOKEN_PHPDOC_TAG => '@[a-z][a-z0-9-\\\\]*+',
 			self::TOKEN_PHPDOC_EOL => '\\r?+\\n[\\x09\\x20]*+(?:\\*(?!/)\\x20?+)?',
 
 			self::TOKEN_FLOAT => '(?:-?[0-9]++\\.[0-9]*+(?:e-?[0-9]++)?)|(?:-?[0-9]*+\\.[0-9]++(?:e-?[0-9]++)?)|(?:-?[0-9]++e-?[0-9]++)',

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -89,6 +89,7 @@ class PhpDocParserTest extends TestCase
 	 * @dataProvider provideAssertTagsData
 	 * @dataProvider provideRealWorldExampleData
 	 * @dataProvider provideDescriptionWithOrWithoutHtml
+	 * @dataProvider provideTagsWithBackslash
 	 */
 	public function testParse(
 		string $label,
@@ -4454,6 +4455,20 @@ Finder::findFiles('*.php')
 				new PhpDocTagNode(
 					'@special3',
 					new GenericTagValueNode('Foo')
+				),
+			]),
+		];
+	}
+
+	public function provideTagsWithBackslash(): Iterator
+	{
+		yield [
+			'OK without description and tag with backslash in it',
+			'/** @ORM\Mapping\Entity User */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@ORM\Mapping\Entity',
+					new GenericTagValueNode('User')
 				),
 			]),
 		];

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -4463,12 +4463,23 @@ Finder::findFiles('*.php')
 	public function provideTagsWithBackslash(): Iterator
 	{
 		yield [
-			'OK without description and tag with backslash in it',
+			'OK without description and tag with backslashes in it',
 			'/** @ORM\Mapping\Entity User */',
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@ORM\Mapping\Entity',
 					new GenericTagValueNode('User')
+				),
+			]),
+		];
+
+		yield [
+			'OK without description and tag with backslashes in it and parenthesis',
+			'/** @ORM\Mapping\JoinColumn(name="column_id", referencedColumnName="id") */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@ORM\Mapping\JoinColumn',
+					new GenericTagValueNode('(name="column_id", referencedColumnName="id")')
 				),
 			]),
 		];


### PR DESCRIPTION
As discussed in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6619#issuecomment-1236329281.