### PR TITLE
In param tags variable name is optional

### DIFF
--- a/doc/grammars/phpdoc-param.peg
+++ b/doc/grammars/phpdoc-param.peg
@@ -1,5 +1,5 @@
 PhpDocParam
-  = AnnotationName Type? IsReference? IsVariadic? ParameterName Description?
+  = AnnotationName Type? IsReference? IsVariadic? ParameterName? Description?
 
 AnnotationName
   = '@param'

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -266,9 +266,13 @@ class PhpDocParser
 			$type = $this->typeParser->parse($tokens);
 		}
 
+		if ($type !== null) {
+			$tokens->mustBePrecededByHorizontalWhitespace();
+		}
+
 		$isReference = $tokens->tryConsumeTokenType(Lexer::TOKEN_REFERENCE);
 		$isVariadic = $tokens->tryConsumeTokenType(Lexer::TOKEN_VARIADIC);
-		$parameterName = $this->parseRequiredVariableName($tokens);
+		$parameterName = $this->parseOptionalVariableName($tokens);
 		$description = $this->parseOptionalDescription($tokens);
 
 		if ($type !== null) {

--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -74,6 +74,15 @@ class TokenIterator
 		return ($this->tokens[$this->index - 1][Lexer::TYPE_OFFSET] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
 	}
 
+	public function mustBePrecededByHorizontalWhitespace(): void
+	{
+		if ($this->isPrecededByHorizontalWhitespace()) {
+			return;
+		}
+
+		$this->throwError(Lexer::TOKEN_HORIZONTAL_WS);
+	}
+
 
 	/**
 	 * @throws ParserException

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -282,6 +282,40 @@ class PhpDocParserTest extends TestCase
 		];
 
 		yield [
+			'ok without parameter name and description',
+			'/** @param Foo */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@param',
+					new ParamTagValueNode(
+						new IdentifierTypeNode('Foo'),
+						false,
+						'',
+						'',
+						false
+					)
+				),
+			]),
+		];
+
+		yield [
+			'ok without parameter name and with description',
+			'/** @param Foo optional description */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@param',
+					new ParamTagValueNode(
+						new IdentifierTypeNode('Foo'),
+						false,
+						'',
+						'optional description',
+						false
+					)
+				),
+			]),
+		];
+
+		yield [
 			'invalid without type, parameter name and description',
 			'/** @param */',
 			new PhpDocNode([
@@ -389,44 +423,6 @@ class PhpDocParserTest extends TestCase
 							Lexer::TOKEN_VARIABLE,
 							16,
 							Lexer::TOKEN_IDENTIFIER
-						)
-					)
-				),
-			]),
-		];
-
-		yield [
-			'invalid without parameter name and description',
-			'/** @param Foo */',
-			new PhpDocNode([
-				new PhpDocTagNode(
-					'@param',
-					new InvalidTagValueNode(
-						'Foo',
-						new ParserException(
-							'*/',
-							Lexer::TOKEN_CLOSE_PHPDOC,
-							15,
-							Lexer::TOKEN_VARIABLE
-						)
-					)
-				),
-			]),
-		];
-
-		yield [
-			'invalid without parameter name and with description',
-			'/** @param Foo optional description */',
-			new PhpDocNode([
-				new PhpDocTagNode(
-					'@param',
-					new InvalidTagValueNode(
-						'Foo optional description',
-						new ParserException(
-							'optional',
-							Lexer::TOKEN_IDENTIFIER,
-							15,
-							Lexer::TOKEN_VARIABLE
 						)
 					)
 				),
@@ -4257,7 +4253,7 @@ Finder::findFiles('*.php')
 			'malformed const fetch',
 			'/** @param Foo::** $a */',
 			new PhpDocNode([
-				new PhpDocTagNode('@param', new InvalidTagValueNode('Foo::** $a', new ParserException('*', Lexer::TOKEN_WILDCARD, 17, Lexer::TOKEN_VARIABLE))),
+				new PhpDocTagNode('@param', new InvalidTagValueNode('Foo::** $a', new ParserException('*', Lexer::TOKEN_WILDCARD, 17, Lexer::TOKEN_HORIZONTAL_WS))),
 			]),
 		];
 


### PR DESCRIPTION
Accoring to the PRS-5 standard paramnames are optional. The parser does not force docblocks to be fully valid, so it's ok to have multiple param tags without variable name. However this should never happen in real world docblocks.

Fixes #164