### PR TITLE
Allow method tag return type to be by reference

### DIFF
--- a/doc/grammars/phpdoc-method.peg
+++ b/doc/grammars/phpdoc-method.peg
@@ -1,5 +1,5 @@
 PhpDocMethod
-  = AnnotationName IsStatic? MethodReturnType? MethodName MethodParameters? Description?
+  = AnnotationName IsStatic? MethodReturnType? IsReference?MethodName MethodParameters? Description?
 
 AnnotationName
   = '@method'

--- a/src/Ast/PhpDoc/MethodTagValueNode.php
+++ b/src/Ast/PhpDoc/MethodTagValueNode.php
@@ -26,13 +26,17 @@ class MethodTagValueNode implements PhpDocTagValueNode
 	/** @var string (may be empty) */
 	public $description;
 
-	public function __construct(bool $isStatic, ?TypeNode $returnType, string $methodName, array $parameters, string $description)
+	/** @var bool */
+	public $isByReference;
+
+	public function __construct(bool $isStatic, ?TypeNode $returnType, string $methodName, array $parameters, string $description, bool $isByReference = false)
 	{
 		$this->isStatic = $isStatic;
 		$this->returnType = $returnType;
 		$this->methodName = $methodName;
 		$this->parameters = $parameters;
 		$this->description = $description;
+		$this->isByReference = $isByReference;
 	}
 
 
@@ -42,7 +46,8 @@ class MethodTagValueNode implements PhpDocTagValueNode
 		$returnType = $this->returnType !== null ? "{$this->returnType} " : '';
 		$parameters = implode(', ', $this->parameters);
 		$description = $this->description !== '' ? " {$this->description}" : '';
-		return "{$static}{$returnType}{$this->methodName}({$parameters}){$description}";
+		$reference = $this->isByReference === true ? '&' : '';
+		return "{$static}{$returnType}{$reference}{$this->methodName}({$parameters}){$description}";
 	}
 
 }

--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -179,6 +179,17 @@ class TokenIterator
 		$this->index++;
 	}
 
+	public function prev(): void
+	{
+		$this->index--;
+
+		if ($this->tokens[$this->index][Lexer::TYPE_OFFSET] !== Lexer::TOKEN_HORIZONTAL_WS) {
+			return;
+		}
+
+		$this->index--;
+	}
+
 	/** @phpstan-impure */
 	public function forwardToTheEnd(): void
 	{

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -44,6 +44,7 @@ use PHPStan\PhpDocParser\Ast\Type\ConditionalTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
@@ -2134,6 +2135,63 @@ class PhpDocParserTest extends TestCase
 							),
 						],
 						''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK non-static, with reference return type',
+			'/** @method Foo &foo() */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@method',
+					new MethodTagValueNode(
+						false,
+						new IdentifierTypeNode('Foo'),
+						'foo',
+						[],
+						'',
+						true
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK non-static, with reference return type be in intersection type',
+			'/** @method Foo & Bar &foo() */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@method',
+					new MethodTagValueNode(
+						false,
+						new IntersectionTypeNode([
+							new IdentifierTypeNode('Foo'),
+							new IdentifierTypeNode('Bar'),
+						]),
+						'foo',
+						[],
+						'',
+						true
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK non-static, with reference return type with extra whitespace',
+			'/** @method Foo & foo() */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@method',
+					new MethodTagValueNode(
+						false,
+						new IdentifierTypeNode('Foo'),
+						'foo',
+						[],
+						'',
+						true
 					)
 				),
 			]),


### PR DESCRIPTION
Like normal methods the method tag might return by reference. This fix introduces the support of reference return types. However in a real world implementation it not very likely one would ever mix reference return types with none reference return types. If even possible using php __call.

fixes #158 