### PR TITLE
Add specialized tags support

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -146,7 +146,7 @@ class Lexer
 
 			self::TOKEN_OPEN_PHPDOC => '/\\*\\*(?=\\s)\\x20?+',
 			self::TOKEN_CLOSE_PHPDOC => '\\*/',
-			self::TOKEN_PHPDOC_TAG => '@[a-z][a-z0-9-\\\\]*+',
+			self::TOKEN_PHPDOC_TAG => '@(?:[a-z][a-z0-9-\\\\]+:)?[a-z][a-z0-9-\\\\]*+',
 			self::TOKEN_PHPDOC_EOL => '\\r?+\\n[\\x09\\x20]*+(?:\\*(?!/)\\x20?+)?',
 
 			self::TOKEN_FLOAT => '(?:-?[0-9]++\\.[0-9]*+(?:e-?[0-9]++)?)|(?:-?[0-9]*+\\.[0-9]++(?:e-?[0-9]++)?)|(?:-?[0-9]++e-?[0-9]++)',

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -75,6 +75,7 @@ class PhpDocParserTest extends TestCase
 
 	/**
 	 * @dataProvider provideTagsWithNumbers
+	 * @dataProvider provideSpecializedTags
 	 * @dataProvider provideParamTagsData
 	 * @dataProvider provideTypelessParamTagsData
 	 * @dataProvider provideVarTagsData
@@ -4845,6 +4846,22 @@ Finder::findFiles('*.php')
 						new IdentifierTypeNode('string'),
 						'$s',
 						'description'
+					)
+				),
+			]),
+		];
+	}
+
+	public function provideSpecializedTags(): Iterator
+	{
+		yield [
+			'Ok specialized tag',
+			'/** @special:param this is special */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@special:param',
+					new GenericTagValueNode(
+						'this is special'
 					)
 				),
 			]),


### PR DESCRIPTION
Specialized tags are tags including a signle colon.

Fixes https://github.com/phpstan/phpdoc-parser/issues/157