### PR TITLE
Support unsealed array shapes

### DIFF
--- a/src/Ast/Type/ArrayShapeNode.php
+++ b/src/Ast/Type/ArrayShapeNode.php
@@ -13,15 +13,25 @@ class ArrayShapeNode implements TypeNode
 	/** @var ArrayShapeItemNode[] */
 	public $items;
 
-	public function __construct(array $items)
+	/** @var bool */
+	public $sealed;
+
+	public function __construct(array $items, bool $sealed = true)
 	{
 		$this->items = $items;
+		$this->sealed = $sealed;
 	}
 
 
 	public function __toString(): string
 	{
-		return 'array{' . implode(', ', $this->items) . '}';
+		$items = $this->items;
+
+		if ($this->sealed) {
+			$items[] = '...';
+		}
+
+		return 'array{' . implode(', ', $items) . '}';
 	}
 
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -503,29 +503,32 @@ class TypeParser
 	private function parseArrayShape(TokenIterator $tokens, Ast\Type\TypeNode $type): Ast\Type\ArrayShapeNode
 	{
 		$tokens->consumeTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET);
-		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
-			return new Ast\Type\ArrayShapeNode([]);
-		}
 
-		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
-		$items = [$this->parseArrayShapeItem($tokens)];
+		$items = [];
+		$sealed = true;
 
-		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
-		while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA)) {
+		do {
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
+
 			if ($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET)) {
-				// trailing comma case
 				return new Ast\Type\ArrayShapeNode($items);
 			}
 
+			if ($tokens->tryConsumeTokenType(Lexer::TOKEN_VARIADIC)) {
+				$sealed = false;
+				$tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA);
+				break;
+			}
+
 			$items[] = $this->parseArrayShapeItem($tokens);
+
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
-		}
+		} while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA));
 
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET);
 
-		return new Ast\Type\ArrayShapeNode($items);
+		return new Ast\Type\ArrayShapeNode($items, $sealed);
 	}
 
 

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -600,6 +600,75 @@ class TypeParserTest extends TestCase
 				]),
 			],
 			[
+				'array{a: int, b: int, ...}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('b'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				], false),
+			],
+			[
+				'array{int, string, ...}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('string')
+					),
+				], false),
+			],
+			[
+				'array{...}',
+				new ArrayShapeNode([], false),
+			],
+			[
+				'array{
+				 *	a: int,
+				 *	...
+				 *}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				], false),
+			],
+			[
+				'array{
+					a: int,
+					...,
+				}',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new IdentifierTypeNode('a'),
+						false,
+						new IdentifierTypeNode('int')
+					),
+				], false),
+			],
+			[
+				'array{int, ..., string}',
+				new ParserException(
+					'string',
+					Lexer::TOKEN_IDENTIFIER,
+					16,
+					Lexer::TOKEN_CLOSE_CURLY_BRACKET
+				),
+			],
+			[
 				'callable(): Foo',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),


### PR DESCRIPTION
This PR adds support for `array{foo: int, ...}` syntax (phpstan/phpstan#8438).