### PR TITLE
Add support for list shapes

### DIFF
--- a/src/Ast/Type/ArrayShapeNode.php
+++ b/src/Ast/Type/ArrayShapeNode.php
@@ -8,6 +8,9 @@ use function implode;
 class ArrayShapeNode implements TypeNode
 {
 
+	public const KIND_ARRAY = 'array';
+	public const KIND_LIST = 'list';
+
 	use NodeAttributes;
 
 	/** @var ArrayShapeItemNode[] */
@@ -16,10 +19,17 @@ class ArrayShapeNode implements TypeNode
 	/** @var bool */
 	public $sealed;
 
-	public function __construct(array $items, bool $sealed = true)
+	/** @var self::KIND_* */
+	public $kind;
+
+	/**
+	 * @param self::KIND_* $kind
+	 */
+	public function __construct(array $items, bool $sealed = true, string $kind = self::KIND_ARRAY)
 	{
 		$this->items = $items;
 		$this->sealed = $sealed;
+		$this->kind = $kind;
 	}
 
 
@@ -31,7 +41,7 @@ class ArrayShapeNode implements TypeNode
 			$items[] = '...';
 		}
 
-		return 'array{' . implode(', ', $items) . '}';
+		return $this->kind . '{' . implode(', ', $items) . '}';
 	}
 
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -5,6 +5,7 @@ namespace PHPStan\PhpDocParser\Parser;
 use LogicException;
 use PHPStan\PhpDocParser\Ast;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use function in_array;
 use function strpos;
 use function trim;
 
@@ -123,7 +124,7 @@ class TypeParser
 				} elseif ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
 					$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
 
-				} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
+				} elseif (in_array($type->name, ['array', 'list'], true) && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
 					$type = $this->parseArrayShape($tokens, $type);
 
 					if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
@@ -439,7 +440,7 @@ class TypeParser
 			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
 				$type = $this->parseGeneric($tokens, $type);
 
-			} elseif ($type->name === 'array' && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
+			} elseif (in_array($type->name, ['array', 'list'], true) && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
 				$type = $this->parseArrayShape($tokens, $type);
 			}
 		}

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -125,7 +125,7 @@ class TypeParser
 					$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
 
 				} elseif (in_array($type->name, ['array', 'list'], true) && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
-					$type = $this->parseArrayShape($tokens, $type);
+					$type = $this->parseArrayShape($tokens, $type, $type->name);
 
 					if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
 						$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
@@ -441,7 +441,7 @@ class TypeParser
 				$type = $this->parseGeneric($tokens, $type);
 
 			} elseif (in_array($type->name, ['array', 'list'], true) && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
-				$type = $this->parseArrayShape($tokens, $type);
+				$type = $this->parseArrayShape($tokens, $type, $type->name);
 			}
 		}
 
@@ -500,8 +500,11 @@ class TypeParser
 	}
 
 
-	/** @phpstan-impure */
-	private function parseArrayShape(TokenIterator $tokens, Ast\Type\TypeNode $type): Ast\Type\ArrayShapeNode
+	/**
+	 * @phpstan-impure
+	 * @param Ast\Type\ArrayShapeNode::KIND_* $kind
+	 */
+	private function parseArrayShape(TokenIterator $tokens, Ast\Type\TypeNode $type, string $kind): Ast\Type\ArrayShapeNode
 	{
 		$tokens->consumeTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET);
 
@@ -529,7 +532,7 @@ class TypeParser
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_CURLY_BRACKET);
 
-		return new Ast\Type\ArrayShapeNode($items, $sealed);
+		return new Ast\Type\ArrayShapeNode($items, $sealed, $kind);
 	}
 
 

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -669,6 +669,24 @@ class TypeParserTest extends TestCase
 				),
 			],
 			[
+				'list{
+				 	int,
+				 	string
+				 }',
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('int')
+					),
+					new ArrayShapeItemNode(
+						null,
+						false,
+						new IdentifierTypeNode('string')
+					),
+				]),
+			],
+			[
 				'callable(): Foo',
 				new CallableTypeNode(
 					new IdentifierTypeNode('callable'),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -673,18 +673,22 @@ class TypeParserTest extends TestCase
 				 	int,
 				 	string
 				 }',
-				new ArrayShapeNode([
-					new ArrayShapeItemNode(
-						null,
-						false,
-						new IdentifierTypeNode('int')
-					),
-					new ArrayShapeItemNode(
-						null,
-						false,
-						new IdentifierTypeNode('string')
-					),
-				]),
+				new ArrayShapeNode(
+					[
+						new ArrayShapeItemNode(
+							null,
+							false,
+							new IdentifierTypeNode('int')
+						),
+						new ArrayShapeItemNode(
+							null,
+							false,
+							new IdentifierTypeNode('string')
+						),
+					],
+					true,
+					ArrayShapeNode::KIND_LIST
+				),
 			],
 			[
 				'callable(): Foo',


### PR DESCRIPTION
`strict-array` and `strict-list` were canceled, but list shapes was [introduced in Psalm 5](https://psalm.dev/articles/psalm-5).
It looks like you can merge some of the https://github.com/phpstan/phpdoc-parser/pull/161 patch by @danog. 

refs https://github.com/phpstan/phpstan/issues/8789