### PR TITLE
Micro optimize parseParamTagValue()

### DIFF
--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -333,9 +333,7 @@ class PhpDocParser
 	private function parseParamTagValue(TokenIterator $tokens): Ast\PhpDoc\PhpDocTagValueNode
 	{
 		if (
-			$tokens->isCurrentTokenType(Lexer::TOKEN_REFERENCE)
-			|| $tokens->isCurrentTokenType(Lexer::TOKEN_VARIADIC)
-			|| $tokens->isCurrentTokenType(Lexer::TOKEN_VARIABLE)
+			$tokens->isCurrentTokenType(Lexer::TOKEN_REFERENCE, Lexer::TOKEN_VARIADIC, Lexer::TOKEN_VARIABLE)
 		) {
 			$type = null;
 		} else {


### PR DESCRIPTION
Prevent unnecessary function calls on a hot path

<img width="1151" alt="grafik" src="https://github.com/phpstan/phpdoc-parser/assets/120441/982a3d5a-cabc-4a01-8835-715c375887de">
