### PR TITLE
Support "one-line" comments (starting with //)

### DIFF
--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -9,6 +9,7 @@ use function assert;
 use function count;
 use function in_array;
 use function strlen;
+use function strpos;
 use function substr;
 
 class TokenIterator

--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -380,4 +380,37 @@ class TokenIterator
 			&& $this->hasTokenImmediatelyAfter($endPos, Lexer::TOKEN_CLOSE_PARENTHESES);
 	}
 
+	/**
+	 * Strip PHP style "one-line" comments (text starting with //)
+	 */
+	public function stripComments(): void
+	{
+		$line = 1;
+		$cleanTokens = [];
+		for ($i = 0; $i < count($this->tokens); $i++) {
+			$token = $this->tokens[$i];
+			if (
+				$token[Lexer::TYPE_OFFSET] === Lexer::TOKEN_OTHER
+				&& strpos($token[Lexer::VALUE_OFFSET], '//') === 0
+			) {
+				while (
+					strpos($this->tokens[$i][Lexer::VALUE_OFFSET], "\n") === false
+					&& $i < count($this->tokens)
+				) {
+					$i++;
+				}
+				if ($this->tokens[$i][Lexer::LINE_OFFSET] !== $line) {
+					for ($j = $i + 1; $j < count($this->tokens); $j++) {
+						$this->tokens[$j][Lexer::LINE_OFFSET]--;
+					}
+				}
+			} else {
+				$cleanTokens[] = $token;
+				$line = $token[Lexer::LINE_OFFSET];
+			}
+		}
+
+		$this->tokens = $cleanTokens;
+	}
+
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -43,6 +43,7 @@ class TypeParser
 	/** @phpstan-impure */
 	public function parse(TokenIterator $tokens): Ast\Type\TypeNode
 	{
+		$tokens->stripComments();
 		$startLine = $tokens->currentTokenLine();
 		$startIndex = $tokens->currentTokenIndex();
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_NULLABLE)) {

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -1362,11 +1362,11 @@ EOT,
 						])
 					),
 					new ArrayShapeItemNode(
-						new QuoteAwareConstExprStringNode("double quote keys", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+						new QuoteAwareConstExprStringNode('double quote keys', QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
 						false,
 						new ArrayShapeNode([
 							new ArrayShapeItemNode(
-								new QuoteAwareConstExprStringNode("double_quote_key//1", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								new QuoteAwareConstExprStringNode('double_quote_key//1', QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
 								false,
 								new IdentifierTypeNode('int')
 							),
@@ -1376,7 +1376,7 @@ EOT,
 								new IdentifierTypeNode('string')
 							),
 							new ArrayShapeItemNode(
-								new QuoteAwareConstExprStringNode("double_quote_key\"//\"3", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								new QuoteAwareConstExprStringNode('double_quote_key"//"3', QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
 								false,
 								new IdentifierTypeNode('bool')
 							),
@@ -1390,7 +1390,7 @@ EOT,
 								false,
 								new ArrayShapeNode([
 									new ArrayShapeItemNode(
-										new QuoteAwareConstExprStringNode("double_quote_key//5//1", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+										new QuoteAwareConstExprStringNode('double_quote_key//5//1', QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
 										false,
 										new IdentifierTypeNode('int')
 									),

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -1290,6 +1290,122 @@ class TypeParserTest extends TestCase
 				new UnionTypeNode([new IdentifierTypeNode('int'), new ArrayShapeNode([])]),
 			],
 			[
+				<<<EOT
+				array{ // Array with comments
+			        // Array with single quoted keys
+			        'single quote keys': array{            // Single quoted key
+			            'single_quote_key//1': int,        // Single quoted key with //
+			            'single_quote_key\'//2': string,   // Single quoted key with ' and //
+			            'single_quote_key\'//\'3': bool,   // Single quoted key with 2x ' and //
+			            'single_quote_key"//"4': float,    // Single quoted key with 2x " and //
+			            'single_quote_key"//\'5': array{   // Single quoted key with ', " and //
+			                'single_quote_key//5//1': int, // Single quoted key with 2x //
+			            },
+			            // 'commented_out_array_element//1': int
+			            'single_quote_key//no_whitespace':int,//Single quoted key without whitespace
+			        },
+			        // Array with double quoted keys
+			        "double quote keys": array{           // Double quoted key
+			            "double_quote_key//1": int,        // Double quoted key with //
+			            "double_quote_key'//2": string,    // Double quoted key with ' and //
+			            "double_quote_key\"//\"3": bool,   // Double quoted key with 2x ' and //
+			            "double_quote_key'//'4": float,    // Double quoted key with 2x " and //
+			            "double_quote_key\"//'5": array{  // Double quoted key with ', " and //
+			                "double_quote_key//5//1": int, // Double quoted key with 2x //
+			            },
+			            // "commented_out_array_element//1": int
+			            "double_quote_key//no_whitespace":int,//Double quoted key without whitespace
+			        },
+			    }
+EOT,
+				new ArrayShapeNode([
+					new ArrayShapeItemNode(
+						new QuoteAwareConstExprStringNode('single quote keys', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+						false,
+						new ArrayShapeNode([
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key//1', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new IdentifierTypeNode('int')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key\'//2', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new IdentifierTypeNode('string')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key\'//\'3', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new IdentifierTypeNode('bool')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key"//"4', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new IdentifierTypeNode('float')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key"//\'5', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new ArrayShapeNode([
+									new ArrayShapeItemNode(
+										new QuoteAwareConstExprStringNode('single_quote_key//5//1', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+										false,
+										new IdentifierTypeNode('int')
+									),
+								])
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('single_quote_key//no_whitespace', QuoteAwareConstExprStringNode::SINGLE_QUOTED),
+								false,
+								new IdentifierTypeNode('int')
+							),
+						])
+					),
+					new ArrayShapeItemNode(
+						new QuoteAwareConstExprStringNode("double quote keys", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+						false,
+						new ArrayShapeNode([
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode("double_quote_key//1", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new IdentifierTypeNode('int')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode("double_quote_key'//2", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new IdentifierTypeNode('string')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode("double_quote_key\"//\"3", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new IdentifierTypeNode('bool')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode("double_quote_key'//'4", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new IdentifierTypeNode('float')
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode("double_quote_key\"//'5", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new ArrayShapeNode([
+									new ArrayShapeItemNode(
+										new QuoteAwareConstExprStringNode("double_quote_key//5//1", QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+										false,
+										new IdentifierTypeNode('int')
+									),
+								])
+							),
+							new ArrayShapeItemNode(
+								new QuoteAwareConstExprStringNode('double_quote_key//no_whitespace', QuoteAwareConstExprStringNode::DOUBLE_QUOTED),
+								false,
+								new IdentifierTypeNode('int')
+							),
+						])
+					),
+				]),
+			],
+			[
 				'callable(' . PHP_EOL .
 				'  Foo' . PHP_EOL .
 				'): void',


### PR DESCRIPTION
This PR adds support for comments inside type definitions, e.g.:

```php
/** @return array { // Array with comments.
 *     // Comments can be placed on their own line. 
 *     foo: string, // An array key description.
 *     bar: array {, // Another array key description.
 *         'foo//bar': string, // Array key with "//" in it's name.
 *     },
 * }
 */
```

Fixes #184