### PR TITLE
[PhpDoc] Add SpacelessPhpDocTagNode

### DIFF
--- a/src/Ast/PhpDoc/SpacelessPhpDocTagNode.php
+++ b/src/Ast/PhpDoc/SpacelessPhpDocTagNode.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\PhpDoc;
+
+use Stringable;
+
+final class SpacelessPhpDocTagNode extends PhpDocTagNode implements Stringable
+{
+    public function __toString(): string
+    {
+        return $this->name . $this->value;
+    }
+}

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -30,6 +30,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\SelfOutTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\SpacelessPhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TypeAliasImportTagValueNode;
@@ -197,6 +198,10 @@ final class Printer
 		if ($node instanceof PhpDocTagNode) {
 			if ($node->value instanceof DoctrineTagValueNode) {
 				return $this->print($node->value);
+			}
+
+			if ($node instanceof SpacelessPhpDocTagNode) {
+				return trim(sprintf('%s%s', $node->name, $this->print($node->value)));
 			}
 
 			return trim(sprintf('%s %s', $node->name, $this->print($node->value)));


### PR DESCRIPTION
@ondrejmirtes since the `Printer` class is `final`, in rector-src for usecase of our custom `SpacelessPhpDocTagNode` for FQCN doctrine use, I add this to the `PhpDoc` namespace so can be used on rector-src to avoid space:

```diff
- * @Table ("Table_Name")
+ * @Table("Table_Name")
```

https://github.com/rectorphp/rector-src/pull/4573#discussion_r1274786024 . We can't use `parseDoctrineAnnotations` flag on extended `PhpDocParser` at 

https://github.com/rectorphp/rector-src/blob/729f03b6e9abccb7c4d7a4515e4dfed61e725e71/packages/BetterPhpDocParser/PhpDocParser/BetterPhpDocParser.php#L57-L58

as it cause invalid output:

```diff
 /**
- * @Table("Table_Name")
+ * @Doctrine\ORM\Mapping\Table("Table_Name")
```
