### PR TITLE
Allow asserting the type of `$this`

### DIFF
--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -1127,15 +1127,13 @@ class PhpDocParser
 	{
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_THIS_VARIABLE)) {
 			$parameter = '$this';
-			$requirePropertyOrMethod = true;
 			$tokens->next();
 		} else {
 			$parameter = $tokens->currentTokenValue();
-			$requirePropertyOrMethod = false;
 			$tokens->consumeTokenType(Lexer::TOKEN_VARIABLE);
 		}
 
-		if ($requirePropertyOrMethod || $tokens->isCurrentTokenType(Lexer::TOKEN_ARROW)) {
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_ARROW)) {
 			$tokens->consumeTokenType(Lexer::TOKEN_ARROW);
 
 			$propertyOrMethod = $tokens->currentTokenValue();

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -4563,21 +4563,56 @@ some text in the middle'
 		];
 
 		yield [
-			'invalid $this',
+			'OK $this',
 			'/** @phpstan-assert Type $this */',
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@phpstan-assert',
-					new InvalidTagValueNode(
-						'Type $this',
-						new ParserException(
-							'*/',
-							Lexer::TOKEN_CLOSE_PHPDOC,
-							31,
-							Lexer::TOKEN_ARROW,
-							null,
-							1
-						)
+					new AssertTagValueNode(
+						new IdentifierTypeNode('Type'),
+						'$this',
+						false,
+						''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK $this with description',
+			'/** @phpstan-assert Type $this assert Type to $this */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-assert',
+					new AssertTagValueNode(
+						new IdentifierTypeNode('Type'),
+						'$this',
+						false,
+						'assert Type to $this'
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK $this with generic type',
+			'/** @phpstan-assert GenericType<T> $this */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-assert',
+					new AssertTagValueNode(
+						new GenericTypeNode(
+							new IdentifierTypeNode('GenericType'),
+							[
+								new IdentifierTypeNode('T'),
+							],
+							[
+								GenericTypeNode::VARIANCE_INVARIANT,
+							]
+						),
+						'$this',
+						false,
+						''
 					)
 				),
 			]),


### PR DESCRIPTION
Closes phpstan/phpstan#8904

I've also added some tests on the PHPStan side, to ensure the type assertions work properly: phpstan/phpstan-src#2609