### PR TITLE
Add Ecosystem section to README doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,8 @@ Afterwards you can either run the whole build including linting and coding stand
 or run only tests using
 
     make tests
+
+## Ecosystem
+
+The following project is inspired by this library
+- [@rightcapital/php-parser](https://github.com/RightCapitalHQ/phpdoc-parser) - PHP Parser TypeScript version

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Ast/NodeTraverser.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between 2 and 2 will always evaluate to true\\.$#"
-			count: 2
-			path: src/Ast/NodeTraverser.php
-
-		-
 			message: "#^Variable property access on PHPStan\\\\PhpDocParser\\\\Ast\\\\Node\\.$#"
 			count: 1
 			path: src/Ast/NodeTraverser.php


### PR DESCRIPTION
# About this PR

I attempted to enhance the README file by including an Ecosystem section to acknowledge other projects that have been influenced by this amazing library. 

Currently, the only project I have added is a TypeScript version PHPDoc parser developed by my company, RightCapital. The URL for this project is https://github.com/RightCapitalHQ/phpdoc-parser.

# Some information about the PHPDoc parser TypeScript version.

as you may already know. RightCapital uses PHP as the main backend language so far and uses PHPStan to improve our PHP code quality. we use it a lot, we also donate to this awesome project. 

Our backend code has good type annotations and we also want that information could be used for the front-end developer by automatically generating TypeScript types(we are developing our front-end system by using TypeScript). we developed a system to generate types from backend code to TypeScript types. especially the type annotations from the php doc are the important part. so we referred to this Library and created a TypeScript version PHPDoc parser for doing this. after getting PHPDoc AST from php code. we also have a transpiler to convert it to TypeScript AST for getting the final TypeScript code. 

so PHPDoc parser TypeScript is a part of that project. and we recently decided to make it open-source.
