### PR TITLE
support comments in array shape

### DIFF
--- a/.github/workflows/apiref.yml
+++ b/.github/workflows/apiref.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Checkout build-cs"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "phpstan/build-cs"
           path: "build-cs"
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.PHPSTAN_BOT_TOKEN }}

--- a/.github/workflows/merge-maintained-branch.yml
+++ b/.github/workflows/merge-maintained-branch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "Merge branch"
         uses: everlytic/branch-merge@1.1.5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/send-pr.yml
+++ b/.github/workflows/send-pr.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: "8.1"
 
       - name: "Checkout phpstan-src"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: phpstan/phpstan-src
           path: phpstan-src

--- a/.github/workflows/test-slevomat-coding-standard.yml
+++ b/.github/workflows/test-slevomat-coding-standard.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Checkout Slevomat Coding Standard"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: slevomat/coding-standard
           path: slevomat-cs

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Ast/NodeTraverser.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between 2 and 2 will always evaluate to true\\.$#"
-			count: 2
-			path: src/Ast/NodeTraverser.php
-
-		-
 			message: "#^Variable property access on PHPStan\\\\PhpDocParser\\\\Ast\\\\Node\\.$#"
 			count: 1
 			path: src/Ast/NodeTraverser.php

--- a/src/Ast/Attribute.php
+++ b/src/Ast/Attribute.php
@@ -13,4 +13,6 @@ final class Attribute
 
 	public const ORIGINAL_NODE = 'originalNode';
 
+	public const COMMENTS = 'comments';
+
 }

--- a/src/Ast/Comment.php
+++ b/src/Ast/Comment.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast;
+
+use function trim;
+
+class Comment
+{
+
+	/** @var string */
+	public $text;
+
+	/** @var int */
+	public $startLine;
+
+	/** @var int */
+	public $startIndex;
+
+	public function __construct(string $text, int $startLine = -1, int $startIndex = -1)
+	{
+		$this->text = $text;
+		$this->startLine = $startLine;
+		$this->startIndex = $startIndex;
+	}
+
+	public function getReformattedText(): ?string
+	{
+		return trim($this->text);
+	}
+
+}

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -50,6 +50,8 @@ class Lexer
 	public const TOKEN_NEGATED = 35;
 	public const TOKEN_ARROW = 36;
 
+	public const TOKEN_COMMENT = 37;
+
 	public const TOKEN_LABELS = [
 		self::TOKEN_REFERENCE => '\'&\'',
 		self::TOKEN_UNION => '\'|\'',
@@ -65,6 +67,7 @@ class Lexer
 		self::TOKEN_OPEN_CURLY_BRACKET => '\'{\'',
 		self::TOKEN_CLOSE_CURLY_BRACKET => '\'}\'',
 		self::TOKEN_COMMA => '\',\'',
+		self::TOKEN_COMMENT => '\'//\'',
 		self::TOKEN_COLON => '\':\'',
 		self::TOKEN_VARIADIC => '\'...\'',
 		self::TOKEN_DOUBLE_COLON => '\'::\'',
@@ -160,6 +163,7 @@ class Lexer
 			self::TOKEN_CLOSE_CURLY_BRACKET => '\\}',
 
 			self::TOKEN_COMMA => ',',
+			self::TOKEN_COMMENT => '((?<![:/])\/\/[^\n]*)',
 			self::TOKEN_VARIADIC => '\\.\\.\\.',
 			self::TOKEN_DOUBLE_COLON => '::',
 			self::TOKEN_DOUBLE_ARROW => '=>',

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -1127,15 +1127,13 @@ class PhpDocParser
 	{
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_THIS_VARIABLE)) {
 			$parameter = '$this';
-			$requirePropertyOrMethod = true;
 			$tokens->next();
 		} else {
 			$parameter = $tokens->currentTokenValue();
-			$requirePropertyOrMethod = false;
 			$tokens->consumeTokenType(Lexer::TOKEN_VARIABLE);
 		}
 
-		if ($requirePropertyOrMethod || $tokens->isCurrentTokenType(Lexer::TOKEN_ARROW)) {
+		if ($tokens->isCurrentTokenType(Lexer::TOKEN_ARROW)) {
 			$tokens->consumeTokenType(Lexer::TOKEN_ARROW);
 
 			$propertyOrMethod = $tokens->currentTokenValue();

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -4563,21 +4563,56 @@ some text in the middle'
 		];
 
 		yield [
-			'invalid $this',
+			'OK $this',
 			'/** @phpstan-assert Type $this */',
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@phpstan-assert',
-					new InvalidTagValueNode(
-						'Type $this',
-						new ParserException(
-							'*/',
-							Lexer::TOKEN_CLOSE_PHPDOC,
-							31,
-							Lexer::TOKEN_ARROW,
-							null,
-							1
-						)
+					new AssertTagValueNode(
+						new IdentifierTypeNode('Type'),
+						'$this',
+						false,
+						''
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK $this with description',
+			'/** @phpstan-assert Type $this assert Type to $this */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-assert',
+					new AssertTagValueNode(
+						new IdentifierTypeNode('Type'),
+						'$this',
+						false,
+						'assert Type to $this'
+					)
+				),
+			]),
+		];
+
+		yield [
+			'OK $this with generic type',
+			'/** @phpstan-assert GenericType<T> $this */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-assert',
+					new AssertTagValueNode(
+						new GenericTypeNode(
+							new IdentifierTypeNode('GenericType'),
+							[
+								new IdentifierTypeNode('T'),
+							],
+							[
+								GenericTypeNode::VARIANCE_INVARIANT,
+							]
+						),
+						'$this',
+						false,
+						''
 					)
 				),
 			]),

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -117,6 +117,7 @@ class PhpDocParserTest extends TestCase
 	 * @dataProvider provideParamOutTagsData
 	 * @dataProvider provideDoctrineData
 	 * @dataProvider provideDoctrineWithoutDoctrineCheckData
+	 * @dataProvider provideCommentLikeDescriptions
 	 */
 	public function testParse(
 		string $label,
@@ -5557,6 +5558,98 @@ Finder::findFiles('*.php')
 						'description'
 					)
 				),
+			]),
+		];
+	}
+
+	public function provideCommentLikeDescriptions(): Iterator
+	{
+		yield [
+			'Comment after @param',
+			'/** @param int $a // this is a description */',
+			new PhpDocNode([
+				new PhpDocTagNode('@param', new ParamTagValueNode(
+					new IdentifierTypeNode('int'),
+					false,
+					'$a',
+					'// this is a description'
+				)),
+			]),
+		];
+
+		yield [
+			'Comment on a separate line',
+			'/**' . PHP_EOL .
+			' * @param int $a' . PHP_EOL .
+			' * // this is a comment' . PHP_EOL .
+			' */',
+			new PhpDocNode([
+				new PhpDocTagNode('@param', new ParamTagValueNode(
+					new IdentifierTypeNode('int'),
+					false,
+					'$a',
+					''
+				)),
+				new PhpDocTextNode('// this is a comment'),
+			]),
+		];
+		yield [
+			'Comment on a separate line 2',
+			'/**' . PHP_EOL .
+			' * @param int $a' . PHP_EOL .
+			' *' . PHP_EOL .
+			' * // this is a comment' . PHP_EOL .
+			' */',
+			new PhpDocNode([
+				new PhpDocTagNode('@param', new ParamTagValueNode(
+					new IdentifierTypeNode('int'),
+					false,
+					'$a',
+					''
+				)),
+				new PhpDocTextNode(''),
+				new PhpDocTextNode('// this is a comment'),
+			]),
+		];
+		yield [
+			'Comment after Doctrine tag 1',
+			'/** @ORM\Doctrine // this is a description */',
+			new PhpDocNode([
+				new PhpDocTagNode('@ORM\Doctrine', new GenericTagValueNode('// this is a description')),
+			]),
+		];
+		yield [
+			'Comment after Doctrine tag 2',
+			'/** @\ORM\Doctrine // this is a description */',
+			new PhpDocNode([
+				new PhpDocTagNode('@\ORM\Doctrine', new DoctrineTagValueNode(
+					new DoctrineAnnotation('@\ORM\Doctrine', []),
+					'// this is a description'
+				)),
+			]),
+		];
+		yield [
+			'Comment after Doctrine tag 3',
+			'/** @\ORM\Doctrine() // this is a description */',
+			new PhpDocNode([
+				new PhpDocTagNode('@\ORM\Doctrine', new DoctrineTagValueNode(
+					new DoctrineAnnotation('@\ORM\Doctrine', []),
+					'// this is a description'
+				)),
+			]),
+		];
+		yield [
+			'Comment after Doctrine tag 4',
+			'/** @\ORM\Doctrine() @\ORM\Entity() // this is a description */',
+			new PhpDocNode([
+				new PhpDocTagNode('@\ORM\Doctrine', new DoctrineTagValueNode(
+					new DoctrineAnnotation('@\ORM\Doctrine', []),
+					''
+				)),
+				new PhpDocTagNode('@\ORM\Entity', new DoctrineTagValueNode(
+					new DoctrineAnnotation('@\ORM\Entity', []),
+					'// this is a description'
+				)),
 			]),
 		];
 	}

--- a/tests/PHPStan/Printer/PrintArrayShapeWithSingleLineCommentTest.php
+++ b/tests/PHPStan/Printer/PrintArrayShapeWithSingleLineCommentTest.php
@@ -1,0 +1,241 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Printer;
+
+use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\NodeTraverser;
+use PHPStan\PhpDocParser\Ast\NodeVisitor;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
+use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use function array_splice;
+use function array_unshift;
+use function count;
+
+class PrintArrayShapeWithSingleLineCommentTest extends PrinterTestBase
+{
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataPrintArrayFormatPreservingAddFront(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{float} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{string} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{// A fractional number
+				 *  float,
+				 *  string} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,int} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   // A fractional number
+				 *   float,
+				 *   string,int} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,
+				 *	 int
+				 * } $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   // A fractional number
+				 *   float,
+				 *   string,
+				 *   int
+				 * } $foo
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrintArrayFormatPreservingAddFront
+	 */
+	public function testPrintFormatPreservingSingleLineAddFront(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ArrayShapeNode) {
+					array_unshift($node->items, PrinterTestBase::withComment(
+						new ArrayShapeItemNode(null, false, new IdentifierTypeNode('float')),
+						'// A fractional number'
+					));
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataPrintArrayFormatPreservingAddMiddle(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{float} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{string} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{string,
+				 *  // A fractional number
+				 *  float} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,int} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,
+				 *   // A fractional number
+				 *   float,int} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,
+				 *	 int
+				 * } $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param array{
+				 *   string,
+				 *   // A fractional number
+				 *   float,
+				 *   int
+				 * } $foo
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrintArrayFormatPreservingAddMiddle
+	 */
+	public function testPrintFormatPreservingSingleLineAddMiddle(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				$newItem = PrinterTestBase::withComment(
+					new ArrayShapeItemNode(null, false, new IdentifierTypeNode('float')),
+					'// A fractional number'
+				);
+
+				if ($node instanceof ArrayShapeNode) {
+					if (count($node->items) === 0) {
+						$node->items[] = $newItem;
+					} else {
+						array_splice($node->items, 1, 0, [$newItem]);
+					}
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+}

--- a/tests/PHPStan/Printer/PrintCallableWithSingleLineCommentTest.php
+++ b/tests/PHPStan/Printer/PrintCallableWithSingleLineCommentTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Printer;
+
+use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\NodeTraverser;
+use PHPStan\PhpDocParser\Ast\NodeVisitor;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\CallableTypeParameterNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use function array_unshift;
+
+class PrintCallableWithSingleLineCommentTest extends PrinterTestBase
+{
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataAddCommentToParamsFront(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param callable(Bar $bar): int $a
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param callable(// never pet a burning dog
+				 *  Foo $foo,
+				 *  Bar $bar): int $a
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataAddCommentToParamsFront
+	 */
+	public function testAddCommentToParamsFront(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof CallableTypeNode) {
+					array_unshift($node->parameters, PrinterTestBase::withComment(
+						new CallableTypeParameterNode(new IdentifierTypeNode('Foo'), false, false, '$foo', false),
+						'// never pet a burning dog'
+					));
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataPrintArrayFormatPreservingAddMiddle(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param callable(Foo $foo): int $a
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param callable(Foo $foo,
+				 *  // never pet a burning dog
+				 *  Bar $bar): int $a
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrintArrayFormatPreservingAddMiddle
+	 */
+	public function testPrintFormatPreservingSingleLineAddMiddle(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof CallableTypeNode) {
+					$node->parameters[] = PrinterTestBase::withComment(
+						new CallableTypeParameterNode(new IdentifierTypeNode('Bar'), false, false, '$bar', false),
+						'// never pet a burning dog'
+					);
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+}

--- a/tests/PHPStan/Printer/PrintObjectWithSingleLineCommentTest.php
+++ b/tests/PHPStan/Printer/PrintObjectWithSingleLineCommentTest.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Printer;
+
+use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\NodeTraverser;
+use PHPStan\PhpDocParser\Ast\NodeVisitor;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeItemNode;
+use PHPStan\PhpDocParser\Ast\Type\ObjectShapeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use function array_splice;
+use function array_unshift;
+use function count;
+
+class PrintObjectWithSingleLineCommentTest extends PrinterTestBase
+{
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataPrintArrayFormatPreservingAddFront(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{bar: string} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{// A fractional number
+				 *  foo: float,
+				 *  bar: string} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   bar:string,naz:int} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   // A fractional number
+				 *   foo: float,
+				 *   bar:string,naz:int} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   bar:string,
+				 *	 naz:int
+				 * } $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   // A fractional number
+				 *   foo: float,
+				 *   bar:string,
+				 *   naz:int
+				 * } $foo
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrintArrayFormatPreservingAddFront
+	 */
+	public function testPrintFormatPreservingSingleLineAddFront(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ObjectShapeNode) {
+					array_unshift($node->items, PrinterTestBase::withComment(
+						new ObjectShapeItemNode(new IdentifierTypeNode('foo'), false, new IdentifierTypeNode('float')),
+						'// A fractional number'
+					));
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+
+	/**
+	 * @return iterable<array{string, string}>
+	 */
+	public function dataPrintObjectFormatPreservingAddMiddle(): iterable
+	{
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{bar: float} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{foo:string} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{foo:string,
+				 *  // A fractional number
+				 *  bar: float} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   foo:string,naz:int} $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   foo:string,
+				 *   // A fractional number
+				 *   bar: float,naz:int} $foo
+				 */'),
+		];
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   foo:string,
+				 *	 naz:int
+				 * } $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param object{
+				 *   foo:string,
+				 *   // A fractional number
+				 *   bar: float,
+				 *   naz:int
+				 * } $foo
+				 */'),
+		];
+	}
+
+	/**
+	 * @dataProvider dataPrintObjectFormatPreservingAddMiddle
+	 */
+	public function testPrintFormatPreservingSingleLineAddMiddle(string $phpDoc, string $expectedResult): void
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ObjectShapeNode) {
+					$newItem = PrinterTestBase::withComment(
+						new ObjectShapeItemNode(new IdentifierTypeNode('bar'), false, new IdentifierTypeNode('float')),
+						'// A fractional number'
+					);
+					if (count($node->items) === 0) {
+						$node->items[] = $newItem;
+					} else {
+						array_splice($node->items, 1, 0, [$newItem]);
+					}
+				}
+
+				return $node;
+			}
+
+		};
+
+		$lexer = new Lexer(true);
+		$tokens = new TokenIterator($lexer->tokenize($phpDoc));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$cloningTraverser = new NodeTraverser([new NodeVisitor\CloningVisitor()]);
+		$newNodes = $cloningTraverser->traverse([$phpDocNode]);
+
+		$changingTraverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode $newNode */
+		[$newNode] = $changingTraverser->traverse($newNodes);
+
+		$printer = new Printer();
+		$actualResult = $printer->printFormatPreserving($newNode, $phpDocNode, $tokens);
+		$this->assertSame($expectedResult, $actualResult);
+
+		$this->assertEquals(
+			$this->unsetAttributes($newNode),
+			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($actualResult))))
+		);
+	}
+
+}

--- a/tests/PHPStan/Printer/PrinterTest.php
+++ b/tests/PHPStan/Printer/PrinterTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\PhpDocParser\Printer;
 
 use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
 use PHPStan\PhpDocParser\Ast\Attribute;
+use PHPStan\PhpDocParser\Ast\Comment;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprArrayItemNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprArrayNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
@@ -39,11 +40,7 @@ use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPUnit\Framework\TestCase;
 use function array_pop;
 use function array_splice;
 use function array_unshift;
@@ -51,29 +48,8 @@ use function array_values;
 use function count;
 use const PHP_EOL;
 
-class PrinterTest extends TestCase
+class PrinterTest extends PrinterTestBase
 {
-
-	/** @var TypeParser */
-	private $typeParser;
-
-	/** @var PhpDocParser */
-	private $phpDocParser;
-
-	protected function setUp(): void
-	{
-		$usedAttributes = ['lines' => true, 'indexes' => true];
-		$constExprParser = new ConstExprParser(true, true, $usedAttributes);
-		$this->typeParser = new TypeParser($constExprParser, true, $usedAttributes);
-		$this->phpDocParser = new PhpDocParser(
-			$this->typeParser,
-			$constExprParser,
-			true,
-			true,
-			$usedAttributes,
-			true
-		);
-	}
 
 	/**
 	 * @return iterable<array{string, string, NodeVisitor}>
@@ -93,12 +69,14 @@ class PrinterTest extends TestCase
 			$noopVisitor,
 		];
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- * @param Foo $foo
- */',
+			self::nowdoc('
+				/**
+				 * @param Foo $foo
+				 */'),
+			self::nowdoc('
+				/**
+				 * @param Foo $foo
+				 */'),
 			$noopVisitor,
 		];
 
@@ -140,33 +118,39 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 */'),
 			$removeFirst,
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- */',
-			'/**
- * @param Bar $bar
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Bar $bar
+			 */'),
 			$removeFirst,
 		];
 
 		yield [
-			'/**
-     * @param Foo $foo
-     * @param Bar $bar
-     */',
-			'/**
-     * @param Bar $bar
-     */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Bar $bar
+			 */'),
 			$removeFirst,
 		];
 
@@ -186,13 +170,15 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- */',
-			'/**
- * @param Foo $foo
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
 			$removeLast,
 		];
 
@@ -213,39 +199,45 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- */',
-			'/**
- * @param Foo $foo
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
 			$removeSecond,
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- * @param Baz $baz
- */',
-			'/**
- * @param Foo $foo
- * @param Baz $baz
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 * @param Baz $baz
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $baz
+			 */'),
 			$removeSecond,
 		];
 
 		yield [
-			'/**
-     * @param Foo $foo
-     * @param Bar $bar
-     * @param Baz $baz
-     */',
-			'/**
-     * @param Foo $foo
-     * @param Baz $baz
-     */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 * @param Baz $baz
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $baz
+			 */'),
 			$removeSecond,
 		];
 
@@ -277,58 +269,66 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/**
-* @return Foo
-* @param Foo $foo
-* @param Bar $bar
-*/',
-			'/**
-* @return Bar
-* @param Foo $foo
-* @param Bar $bar
-*/',
+			self::nowdoc('
+			/**
+			 * @return Foo
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return Bar
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
 			$changeReturnType,
 		];
 
 		yield [
-			'/**
-* @param Foo $foo
-* @return Foo
-* @param Bar $bar
-*/',
-			'/**
-* @param Foo $foo
-* @return Bar
-* @param Bar $bar
-*/',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @return Foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @return Bar
+			 * @param Bar $bar
+			 */'),
 			$changeReturnType,
 		];
 
 		yield [
-			'/**
-* @return Foo
-* @param Foo $foo
-* @param Bar $bar
-*/',
-			'/**
-* @return Bar
-* @param Foo $foo
-* @param Bar $bar
-*/',
+			self::nowdoc('
+			/**
+			 * @return Foo
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return Bar
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
 			$changeReturnType,
 		];
 
 		yield [
-			'/**
-* @param Foo $foo Foo description
-* @return Foo Foo return description
-* @param Bar $bar Bar description
-*/',
-			'/**
-* @param Foo $foo Foo description
-* @return Bar Foo return description
-* @param Bar $bar Bar description
-*/',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo Foo description
+			 * @return Foo Foo return description
+			 * @param Bar $bar Bar description
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo Foo description
+			 * @return Bar Foo return description
+			 * @param Bar $bar Bar description
+			 */'),
 			$changeReturnType,
 		];
 
@@ -353,22 +353,26 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- * @param Baz $a
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Baz $a
+			 */'),
 			$replaceFirst,
 		];
 
 		yield [
-			'/**
-     * @param Foo $foo
-     */',
-			'/**
-     * @param Baz $a
-     */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Baz $a
+			 */'),
 			$replaceFirst,
 		];
 
@@ -388,24 +392,28 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- * @param Baz $a
- * @param Foo $foo
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Baz $a
+			 * @param Foo $foo
+			 */'),
 			$insertFirst,
 		];
 
 		yield [
-			'/**
-     * @param Foo $foo
-     */',
-			'/**
-     * @param Baz $a
-     * @param Foo $foo
-     */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Baz $a
+			 * @param Foo $foo
+			 */'),
 			$insertFirst,
 		];
 
@@ -427,52 +435,60 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- * @param Foo $foo
- * @param Baz $a
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $a
+			 */'),
 			$insertSecond,
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- */',
-			'/**
- * @param Foo $foo
- * @param Baz $a
- * @param Bar $bar
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $a
+			 * @param Bar $bar
+			 */'),
 			$insertSecond,
 		];
 
 		yield [
-			'/**
-     * @param Foo $foo
-     * @param Bar $bar
-     */',
-			'/**
-     * @param Foo $foo
-     * @param Baz $a
-     * @param Bar $bar
-     */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $a
+			 * @param Bar $bar
+			 */'),
 			$insertSecond,
 		];
 
 		yield [
-			'/**
-	 * @param Foo $foo
-	 * @param Bar $bar
-	 */',
-			'/**
-	 * @param Foo $foo
-	 * @param Baz $a
-	 * @param Bar $bar
-	 */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $a
+			 * @param Bar $bar
+			 */'),
 			$insertSecond,
 		];
 
@@ -491,24 +507,28 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo $foo
- */',
-			'/**
- * @param Baz $a
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Baz $a
+			 */'),
 			$replaceLast,
 		];
 
 		yield [
-			'/**
- * @param Foo $foo
- * @param Bar $bar
- */',
-			'/**
- * @param Foo $foo
- * @param Baz $a
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo $foo
+			 * @param Baz $a
+			 */'),
 			$replaceLast,
 		];
 
@@ -526,24 +546,28 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Bar|Baz $foo
- */',
-			'/**
- * @param Foo|Bar|Baz $foo
- */',
+			self::nowdoc('
+			/**
+			 * @param Bar|Baz $foo
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo|Bar|Baz $foo
+			 */'),
 			$insertFirstTypeInUnionType,
 		];
 
 		yield [
-			'/**
- * @param Bar|Baz $foo
- * @param Foo $bar
- */',
-			'/**
- * @param Foo|Bar|Baz $foo
- * @param Foo $bar
- */',
+			self::nowdoc('
+			/**
+			 * @param Bar|Baz $foo
+			 * @param Foo $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo|Bar|Baz $foo
+			 * @param Foo $bar
+			 */'),
 			$insertFirstTypeInUnionType,
 		];
 
@@ -564,12 +588,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo|Bar $bar
- */',
-			'/**
- * @param Lorem|Ipsum $bar
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo|Bar $bar
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Lorem|Ipsum $bar
+			 */'),
 			$replaceTypesInUnionType,
 		];
 
@@ -590,12 +616,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param callable(): void $cb
- */',
-			'/**
- * @param callable(Foo $foo, Bar $bar): void $cb
- */',
+			self::nowdoc('
+			/**
+			 * @param callable(): void $cb
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param callable(Foo $foo, Bar $bar): void $cb
+			 */'),
 			$replaceParametersInCallableType,
 		];
 
@@ -613,12 +641,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param callable(Foo $foo, Bar $bar): void $cb
- */',
-			'/**
- * @param callable(): void $cb
- */',
+			self::nowdoc('
+			/**
+			 * @param callable(Foo $foo, Bar $bar): void $cb
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param callable(): void $cb
+			 */'),
 			$removeParametersInCallableType,
 		];
 
@@ -636,18 +666,20 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param callable(Foo $foo, Bar $bar): void $cb
- * @param callable(): void $cb2
- */',
-			'/**
- * @param Closure(Foo $foo, Bar $bar): void $cb
- * @param Closure(): void $cb2
- */',
+			self::nowdoc('
+			/**
+			 * @param callable(Foo $foo, Bar $bar): void $cb
+			 * @param callable(): void $cb2
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Closure(Foo $foo, Bar $bar): void $cb
+			 * @param Closure(): void $cb2
+			 */'),
 			$changeCallableTypeIdentifier,
 		];
 
-		$addItemsToArrayShape = new class extends AbstractNodeVisitor {
+		$addKeylessItemsToArrayShape = new class extends AbstractNodeVisitor {
 
 			public function enterNode(Node $node)
 			{
@@ -663,6 +695,137 @@ class PrinterTest extends TestCase
 
 		};
 
+		$addItemsWithCommentsToMultilineArrayShape = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ArrayShapeNode) {
+					$commentedNode = new ArrayShapeItemNode(new IdentifierTypeNode('b'), false, new IdentifierTypeNode('int'));
+					$commentedNode->setAttribute(Attribute::COMMENTS, [new Comment('// bar')]);
+					array_splice($node->items, 1, 0, [
+						$commentedNode,
+					]);
+					$commentedNode = new ArrayShapeItemNode(new IdentifierTypeNode('d'), false, new IdentifierTypeNode('string'));
+					$commentedNode->setAttribute(Attribute::COMMENTS, [new Comment(
+						PrinterTest::nowdoc('
+						// first comment')
+					)]);
+					$node->items[] = $commentedNode;
+
+					$commentedNode = new ArrayShapeItemNode(new IdentifierTypeNode('e'), false, new IdentifierTypeNode('string'));
+					$commentedNode->setAttribute(Attribute::COMMENTS, [new Comment(
+						PrinterTest::nowdoc('
+						// second comment')
+					)]);
+					$node->items[] = $commentedNode;
+
+					$commentedNode = new ArrayShapeItemNode(new IdentifierTypeNode('f'), false, new IdentifierTypeNode('string'));
+					$commentedNode->setAttribute(Attribute::COMMENTS, [
+						new Comment('// third comment'),
+						new Comment('// fourth comment'),
+					]);
+					$node->items[] = $commentedNode;
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *  // foo
+			 *	a: int,
+			 *	c: string
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *  // foo
+			 *	a: int,
+			 *  // bar
+			 *  b: int,
+			 *	c: string,
+			 *  // first comment
+			 *  d: string,
+			 *  // second comment
+			 *  e: string,
+			 *  // third comment
+			 *  // fourth comment
+			 *  f: string
+			 * }
+			 */'),
+			$addItemsWithCommentsToMultilineArrayShape,
+		];
+
+		$prependItemsWithCommentsToMultilineArrayShape = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ArrayShapeNode) {
+					$commentedNode = new ArrayShapeItemNode(new IdentifierTypeNode('a'), false, new IdentifierTypeNode('int'));
+					$commentedNode->setAttribute(Attribute::COMMENTS, [new Comment('// first item')]);
+					array_splice($node->items, 0, 0, [
+						$commentedNode,
+					]);
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *  b: int,
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *  // first item
+			 *  a: int,
+			 *  b: int,
+			 * }
+			 */'),
+			$prependItemsWithCommentsToMultilineArrayShape,
+		];
+
+		$changeCommentOnArrayShapeItem = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ArrayShapeItemNode) {
+					$node->setAttribute(Attribute::COMMENTS, [new Comment('// puppies')]);
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   a: int,
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   // puppies
+			 *   a: int,
+			 * }
+			 */'),
+			$changeCommentOnArrayShapeItem,
+		];
+
 		yield [
 			'/**
  * @return array{float}
@@ -670,125 +833,139 @@ class PrinterTest extends TestCase
 			'/**
  * @return array{float, int, string}
  */',
-			$addItemsToArrayShape,
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
- * @return array{float, Foo}
- */',
-			'/**
- * @return array{float, int, Foo, string}
- */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{float, Foo}
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{float, int, Foo, string}
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
- * @return array{
- *   float,
- *   Foo,
- * }
- */',
-			'/**
- * @return array{
- *   float,
- *   int,
- *   Foo,
- *   string,
- * }
- */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   Foo,
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   int,
+			 *   Foo,
+			 *   string,
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
- * @return array{
- *   float,
- *   Foo
- * }
- */',
-			'/**
- * @return array{
- *   float,
- *   int,
- *   Foo,
- *   string
- * }
- */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   Foo
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   int,
+			 *   Foo,
+			 *   string
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
- * @return array{
- *     float,
- *     Foo
- * }
- */',
-			'/**
- * @return array{
- *     float,
- *     int,
- *     Foo,
- *     string
- * }
- */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *     float,
+			 *     Foo
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *     float,
+			 *     int,
+			 *     Foo,
+			 *     string
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
-	 * @return array{
-	 *   float,
-	 *   Foo,
-	 * }
-	 */',
-			'/**
-	 * @return array{
-	 *   float,
-	 *   int,
-	 *   Foo,
-	 *   string,
-	 * }
-	 */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   Foo,
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   int,
+			 *   Foo,
+			 *   string,
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
-     * @return array{
-     *   float,
-     *   Foo
-     * }
-     */',
-			'/**
-     * @return array{
-     *   float,
-     *   int,
-     *   Foo,
-     *   string
-     * }
-     */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   Foo
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *   float,
+			 *   int,
+			 *   Foo,
+			 *   string
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		yield [
-			'/**
-	 * @return array{
-	 *     float,
-	 *     Foo
-	 * }
-	 */',
-			'/**
-	 * @return array{
-	 *     float,
-	 *     int,
-	 *     Foo,
-	 *     string
-	 * }
-	 */',
-			$addItemsToArrayShape,
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *     float,
+			 *     Foo
+			 * }
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return array{
+			 *     float,
+			 *     int,
+			 *     Foo,
+			 *     string
+			 * }
+			 */'),
+			$addKeylessItemsToArrayShape,
 		];
 
 		$addItemsToObjectShape = new class extends AbstractNodeVisitor {
@@ -805,22 +982,73 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @return object{}
- */',
-			'/**
- * @return object{foo: int}
- */',
+			self::nowdoc('
+				/**
+				 * @return object{}
+				 */'),
+			self::nowdoc('
+				/**
+				 * @return object{foo: int}
+				 */'),
 			$addItemsToObjectShape,
 		];
 
 		yield [
-			'/**
- * @return object{bar: string}
- */',
-			'/**
- * @return object{bar: string, foo: int}
- */',
+			self::nowdoc('
+				/**
+				 * @return object{bar: string}
+				 */'),
+			self::nowdoc('
+				/**
+				 * @return object{bar: string, foo: int}
+				 */'),
+			$addItemsToObjectShape,
+		];
+
+		$addItemsWithCommentsToObjectShape = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof ObjectShapeNode) {
+					$item = new ObjectShapeItemNode(new IdentifierTypeNode('foo'), false, new IdentifierTypeNode('int'));
+					$item->setAttribute(Attribute::COMMENTS, [new Comment('// favorite foo')]);
+					$node->items[] = $item;
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			self::nowdoc('
+				/**
+				 * @return object{
+				 *   // your favorite bar
+				 *   bar: string
+				 * }
+				 */'),
+			self::nowdoc('
+				/**
+				 * @return object{
+				 *   // your favorite bar
+				 *   bar: string,
+				 *	 // favorite foo
+				 *	 foo: int
+				 * }
+				 */'),
+			$addItemsWithCommentsToObjectShape,
+		];
+
+		yield [
+			self::nowdoc('
+			/**
+			 * @return object{bar: string}
+			 */'),
+			self::nowdoc('
+			/**
+			 * @return object{bar: string, foo: int}
+			 */'),
 			$addItemsToObjectShape,
 		];
 
@@ -1008,36 +1236,42 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/**
- * @param int $a
- */',
-			'/**
- * @param int $bz
- */',
+			self::nowdoc('
+			/**
+			 * @param int $a
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param int $bz
+			 */'),
 			$changeParameterName,
 		];
 
 		yield [
-			'/**
- * @param int $a
- * @return string
- */',
-			'/**
- * @param int $bz
- * @return string
- */',
+			self::nowdoc('
+			/**
+			 * @param int $a
+			 * @return string
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param int $bz
+			 * @return string
+			 */'),
 			$changeParameterName,
 		];
 
 		yield [
-			'/**
- * @param int $a haha description
- * @return string
- */',
-			'/**
- * @param int $bz haha description
- * @return string
- */',
+			self::nowdoc('
+			/**
+			 * @param int $a haha description
+			 * @return string
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param int $bz haha description
+			 * @return string
+			 */'),
 			$changeParameterName,
 		];
 
@@ -1073,12 +1307,14 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/**
- * @param int $a haha
- */',
-			'/**
- * @param int $a hehe
- */',
+			self::nowdoc('
+			/**
+			 * @param int $a haha
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param int $a hehe
+			 */'),
 			$changeParameterDescription,
 		];
 
@@ -1096,12 +1332,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @param Foo[awesome] $a haha
- */',
-			'/**
- * @param Foo[baz] $a haha
- */',
+			self::nowdoc('
+			/**
+			 * @param Foo[awesome] $a haha
+			 */'),
+			self::nowdoc('
+			/**
+			 * @param Foo[baz] $a haha
+			 */'),
 			$changeOffsetAccess,
 		];
 
@@ -1119,12 +1357,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @phpstan-import-type TypeAlias from AnotherClass as DifferentAlias
- */',
-			'/**
- * @phpstan-import-type TypeAlias from AnotherClass as Ciao
- */',
+			self::nowdoc('
+			/**
+			 * @phpstan-import-type TypeAlias from AnotherClass as DifferentAlias
+			 */'),
+			self::nowdoc('
+			/**
+			 * @phpstan-import-type TypeAlias from AnotherClass as Ciao
+			 */'),
 			$changeTypeAliasImportAs,
 		];
 
@@ -1142,12 +1382,14 @@ class PrinterTest extends TestCase
 		};
 
 		yield [
-			'/**
- * @phpstan-import-type TypeAlias from AnotherClass as DifferentAlias
- */',
-			'/**
- * @phpstan-import-type TypeAlias from AnotherClass
- */',
+			self::nowdoc('
+			/**
+			 * @phpstan-import-type TypeAlias from AnotherClass as DifferentAlias
+			 */'),
+			self::nowdoc('
+			/**
+			 * @phpstan-import-type TypeAlias from AnotherClass
+			 */'),
 			$removeImportAs,
 		];
 
@@ -1559,15 +1801,19 @@ class PrinterTest extends TestCase
 		];
 
 		yield [
-			'/** @Foo(
-			  *     1,
-			  *     2,
-			  *  ) */',
-			'/** @Foo(
-			  *     1,
-			  *     2,
-			  *     3,
-			  *  ) */',
+			self::nowdoc('
+			/** @Foo(
+			 *     1,
+			 *     2,
+			 *  )
+			 */'),
+			self::nowdoc('
+			/** @Foo(
+			 *     1,
+			 *     2,
+			 *     3,
+			 *  )
+			 */'),
 			new class extends AbstractNodeVisitor {
 
 				public function enterNode(Node $node)
@@ -1661,29 +1907,6 @@ class PrinterTest extends TestCase
 			$this->unsetAttributes($newNode),
 			$this->unsetAttributes($this->phpDocParser->parse(new TokenIterator($lexer->tokenize($newPhpDoc))))
 		);
-	}
-
-	private function unsetAttributes(Node $node): Node
-	{
-		$visitor = new class extends AbstractNodeVisitor {
-
-			public function enterNode(Node $node)
-			{
-				$node->setAttribute(Attribute::START_LINE, null);
-				$node->setAttribute(Attribute::END_LINE, null);
-				$node->setAttribute(Attribute::START_INDEX, null);
-				$node->setAttribute(Attribute::END_INDEX, null);
-				$node->setAttribute(Attribute::ORIGINAL_NODE, null);
-
-				return $node;
-			}
-
-		};
-
-		$traverser = new NodeTraverser([$visitor]);
-
-		/** @var PhpDocNode */
-		return $traverser->traverse([$node])[0];
 	}
 
 	/**

--- a/tests/PHPStan/Printer/PrinterTestBase.php
+++ b/tests/PHPStan/Printer/PrinterTestBase.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Printer;
+
+use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
+use PHPStan\PhpDocParser\Ast\Attribute;
+use PHPStan\PhpDocParser\Ast\Comment;
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\NodeTraverser;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPUnit\Framework\TestCase;
+use function array_map;
+use function array_slice;
+use function count;
+use function implode;
+use function preg_match;
+use function preg_replace_callback;
+use function preg_split;
+use function str_repeat;
+use function str_replace;
+use function strlen;
+
+abstract class PrinterTestBase extends TestCase
+{
+
+	/** @var TypeParser */
+	protected $typeParser;
+
+	/** @var PhpDocParser */
+	protected $phpDocParser;
+
+	/**
+	 * @template TNode of Node
+	 * @param TNode $node
+	 * @return TNode
+	 */
+	public static function withComment(Node $node, string $comment): Node
+	{
+		$node->setAttribute(Attribute::COMMENTS, [new Comment($comment)]);
+		return $node;
+	}
+
+	public static function nowdoc(string $str): string
+	{
+		$lines = preg_split('/\\n/', $str);
+
+		if ($lines === false) {
+			return '';
+		}
+
+		if (count($lines) < 2) {
+			return '';
+		}
+
+		// Toss out the first line
+		$lines = array_slice($lines, 1, count($lines) - 1);
+
+		// normalize any tabs to spaces
+		$lines = array_map(static function ($line) {
+			return preg_replace_callback('/(\t+)/m', static function ($matches) {
+				$fixed = str_repeat('  ', strlen($matches[1]));
+				return $fixed;
+			}, $line);
+		}, $lines);
+
+		// take the ws from the first line and subtract them from all lines
+		$matches = [];
+		preg_match('/(^[ \t]+)/', $lines[0] ?? '', $matches);
+
+		$numLines = count($lines);
+		for ($i = 0; $i < $numLines; ++$i) {
+			$lines[$i] = str_replace($matches[0], '', $lines[$i] ?? '');
+		}
+
+		return implode("\n", $lines);
+	}
+
+	protected function setUp(): void
+	{
+		$usedAttributes = ['lines' => true, 'indexes' => true, 'comments' => true];
+		$constExprParser = new ConstExprParser(true, true, $usedAttributes);
+		$this->typeParser = new TypeParser($constExprParser, true, $usedAttributes);
+		$this->phpDocParser = new PhpDocParser(
+			$this->typeParser,
+			$constExprParser,
+			true,
+			true,
+			$usedAttributes,
+			true
+		);
+	}
+
+	protected function unsetAttributes(Node $node): Node
+	{
+		$visitor = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				$node->setAttribute(Attribute::START_LINE, null);
+				$node->setAttribute(Attribute::END_LINE, null);
+				$node->setAttribute(Attribute::START_INDEX, null);
+				$node->setAttribute(Attribute::END_INDEX, null);
+				$node->setAttribute(Attribute::ORIGINAL_NODE, null);
+				$node->setAttribute(Attribute::COMMENTS, null);
+
+				return $node;
+			}
+
+		};
+
+		$traverser = new NodeTraverser([$visitor]);
+
+		/** @var PhpDocNode */
+		return $traverser->traverse([$node])[0];
+	}
+
+}


### PR DESCRIPTION
This is my first experiment in trying to support comments in array shape:

```php
array{
    // a is for apple
	a: int,
}

array{
    // a is for apple
    // a is also for aardvark
	a: int,
}

```

Note: as pointed out by @ondrejmirtes , multi-line comments within a block comment aren't valid PHP, so single line comments like this are the best we can do.