### PR TITLE
Add # as vallid character for variable.

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -141,7 +141,7 @@ class Lexer
 
 			self::TOKEN_IDENTIFIER => '(?:[\\\\]?+[a-z_\\x80-\\xFF][0-9a-z_\\x80-\\xFF-]*+)++',
 			self::TOKEN_THIS_VARIABLE => '\\$this(?![0-9a-z_\\x80-\\xFF])',
-			self::TOKEN_VARIABLE => '\\$[a-z_\\x80-\\xFF][0-9a-z_\\x80-\\xFF]*+',
+			self::TOKEN_VARIABLE => '\\$[a-z_\\x80-\\xFF][0-9a-z_\\x80-\\xFF\\#]*+',
 
 			// '&' followed by TOKEN_VARIADIC, TOKEN_VARIABLE, TOKEN_EQUAL, TOKEN_EQUAL or TOKEN_CLOSE_PARENTHESES
 			self::TOKEN_REFERENCE => '&(?=\\s*+(?:[.,=)]|(?:\\$(?!this(?![0-9a-z_\\x80-\\xFF])))))',


### PR DESCRIPTION
This pull request is related to the issue https://github.com/phpstan/phpstan/issues/9919#issuecomment-1733364261. The problem that it resolves can be seen in https://phpstan.org/r/459a7de6-aa15-42ee-8967-0777088f411e.

Our application is connected to an IBM i DB2 database. The column names are sometimes like the following
 * @property string $PBGAF#
 * @property string $PBGTL#
 * @property string $PBGD#L

Currently, the lexer does not recognize these as valid property names, while in fact, these are valid properties in PHP that can be accessed with $this->{'PBGD#L'} syntax.