### PR TITLE
fix HTML description detection for phpstorm stubs

### DIFF
--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -7,7 +7,9 @@ use PHPStan\PhpDocParser\Ast;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use function in_array;
 use function str_replace;
+use function strlen;
 use function strpos;
+use function substr_compare;
 use function trim;
 
 class TypeParser
@@ -380,10 +382,16 @@ class TypeParser
 			return false;
 		}
 
+		$endTag = '</' . $htmlTagName . '>';
+		$endTagSearchOffset = - strlen($endTag);
+
 		while (!$tokens->isCurrentTokenType(Lexer::TOKEN_END)) {
 			if (
-				$tokens->tryConsumeTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)
-				&& strpos($tokens->currentTokenValue(), '/' . $htmlTagName . '>') !== false
+				(
+					$tokens->tryConsumeTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)
+					&& strpos($tokens->currentTokenValue(), '/' . $htmlTagName . '>') !== false
+				)
+				|| substr_compare($tokens->currentTokenValue(), $endTag, $endTagSearchOffset) === 0
 			) {
 				return true;
 			}

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -1302,6 +1302,20 @@ class PhpDocParserTest extends TestCase
 		];
 
 		yield [
+			'OK with HTML description',
+			'/** @return MongoCollection <p>Returns a collection object representing the new collection.</p> */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@return',
+					new ReturnTagValueNode(
+						new IdentifierTypeNode('MongoCollection'),
+						'<p>Returns a collection object representing the new collection.</p>'
+					)
+				),
+			]),
+		];
+
+		yield [
 			'invalid without type and description',
 			'/** @return */',
 			new PhpDocNode([

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -2166,6 +2166,11 @@ class TypeParserTest extends TestCase
 					false
 				)),
 			],
+			[
+				'MongoCollection <p>Returns a collection object representing the new collection.</p>',
+				new IdentifierTypeNode('MongoCollection'),
+				Lexer::TOKEN_OPEN_ANGLE_BRACKET,
+			],
 		];
 	}
 


### PR DESCRIPTION
Here is a quick attempt to address [this](https://github.com/phpstan/phpstan-src/pull/2622#issuecomment-1816590052)

The problem turned out to be due to the fact that the existing code relies on detecting the `<` of the end tag as a separate token first. But instead it gets `.</p>` as a single token.

I'm not sure whether it's better to fix it this way or by modifying the lexer.

BTW: README.md says that you can just run `composer install` and `make` to build it, but `make cs` doesn't work (build-cs directory is missing - github actions check it out from phpstan's repo).