### PR TITLE
Git export-ignore phpstan-baseline.neon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,5 +13,6 @@ tmp export-ignore
 build-abnfgen.sh export-ignore
 CODE_OF_CONDUCT.md export-ignore
 Makefile export-ignore
+phpstan-baseline.neon export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore


### PR DESCRIPTION
just a drive-by PR because I saw this file in my vendor