### PR TITLE
Upgrade to `nikic/php-parser:^5.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -38,10 +36,6 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
-
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2' || matrix.php-version == '7.3'
-        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "Lint"
         run: "make lint"
@@ -92,8 +86,6 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -120,10 +112,6 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress"
 
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2' || matrix.php-version == '7.3'
-        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
-
       - name: "Tests"
         run: "make tests"
 
@@ -135,8 +123,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
@@ -156,10 +142,6 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress"
-
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2' || matrix.php-version == '7.3'
-        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "PHPStan"
         run: "make phpstan"

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
 	"description": "PHPDoc parser with support for nullable, intersection and generic types",
 	"license": "MIT",
 	"require": {
-		"php": "^7.2 || ^8.0"
+		"php": "^7.4 || ^8.0"
 	},
 	"require-dev": {
 		"doctrine/annotations": "^2.0",
-		"nikic/php-parser": "^4.15",
+		"nikic/php-parser": "^5.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/extension-installer": "^1.0",
 		"phpstan/phpstan": "^1.5",

--- a/tests/PHPStan/Printer/IntegrationPrinterWithPhpParserTest.php
+++ b/tests/PHPStan/Printer/IntegrationPrinterWithPhpParserTest.php
@@ -3,12 +3,11 @@
 namespace PHPStan\PhpDocParser\Printer;
 
 use PhpParser\Comment\Doc;
-use PhpParser\Lexer\Emulative;
 use PhpParser\Node as PhpNode;
 use PhpParser\NodeTraverser as PhpParserNodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor as PhpParserCloningVisitor;
 use PhpParser\NodeVisitorAbstract;
-use PhpParser\Parser\Php7;
+use PhpParser\ParserFactory;
 use PHPStan\PhpDocParser\Ast\AbstractNodeVisitor;
 use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\NodeTraverser;
@@ -66,14 +65,8 @@ class IntegrationPrinterWithPhpParserTest extends TestCase
 	 */
 	public function testPrint(string $file, string $expectedFile, NodeVisitor $visitor): void
 	{
-		$lexer = new Emulative([
-			'usedAttributes' => [
-				'comments',
-				'startLine', 'endLine',
-				'startTokenPos', 'endTokenPos',
-			],
-		]);
-		$phpParser = new Php7($lexer);
+		$phpParser = (new ParserFactory())->createForNewestSupportedVersion();
+
 		$phpTraverser = new PhpParserNodeTraverser();
 		$phpTraverser->addVisitor(new PhpParserCloningVisitor());
 
@@ -85,20 +78,18 @@ class IntegrationPrinterWithPhpParserTest extends TestCase
 
 		/** @var PhpNode[] $oldStmts */
 		$oldStmts = $phpParser->parse($fileContents);
-		$oldTokens = $lexer->getTokens();
+		$oldTokens = $phpParser->getTokens();
 
-		$phpTraverser2 = new PhpParserNodeTraverser();
-		$phpTraverser2->addVisitor(new class ($visitor) extends NodeVisitorAbstract {
+		$phpTraverser->addVisitor(new class ($visitor) extends NodeVisitorAbstract {
 
-			/** @var NodeVisitor */
-			private $visitor;
+			private NodeVisitor $visitor;
 
 			public function __construct(NodeVisitor $visitor)
 			{
 				$this->visitor = $visitor;
 			}
 
-			public function enterNode(PhpNode $phpNode)
+			public function enterNode(PhpNode $phpNode): ?PhpNode
 			{
 				if ($phpNode->getDocComment() === null) {
 					return null;
@@ -137,7 +128,6 @@ class IntegrationPrinterWithPhpParserTest extends TestCase
 
 		/** @var PhpNode[] $newStmts */
 		$newStmts = $phpTraverser->traverse($oldStmts);
-		$newStmts = $phpTraverser2->traverse($newStmts);
 
 		$newCode = $printer->printFormatPreserving($newStmts, $oldStmts, $oldTokens);
 		$this->assertStringEqualsFile($expectedFile, $newCode);


### PR DESCRIPTION
see https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md

notably a php 7.4 version requirement

if we want to retain php 7.2/7.3 support, we could support both v4.0 and v5.0, but given that the main phpstan repo already requires php 8.1, I think this is fine, given the age of php 7.3 (end of life since over 2 years)