### PR TITLE
Support `@phan-` prefixes for recognized doc tags

### DIFF
--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -384,6 +384,7 @@ class PhpDocParser
 				case '@param':
 				case '@phpstan-param':
 				case '@psalm-param':
+				case '@phan-param':
 					$tagValue = $this->parseParamTagValue($tokens);
 					break;
 
@@ -405,12 +406,15 @@ class PhpDocParser
 				case '@var':
 				case '@phpstan-var':
 				case '@psalm-var':
+				case '@phan-var':
 					$tagValue = $this->parseVarTagValue($tokens);
 					break;
 
 				case '@return':
 				case '@phpstan-return':
 				case '@psalm-return':
+				case '@phan-return':
+				case '@phan-real-return':
 					$tagValue = $this->parseReturnTagValue($tokens);
 					break;
 
@@ -420,6 +424,7 @@ class PhpDocParser
 					break;
 
 				case '@mixin':
+				case '@phan-mixin':
 					$tagValue = $this->parseMixinTagValue($tokens);
 					break;
 
@@ -446,18 +451,23 @@ class PhpDocParser
 				case '@psalm-property':
 				case '@psalm-property-read':
 				case '@psalm-property-write':
+				case '@phan-property':
+				case '@phan-property-read':
+				case '@phan-property-write':
 					$tagValue = $this->parsePropertyTagValue($tokens);
 					break;
 
 				case '@method':
 				case '@phpstan-method':
 				case '@psalm-method':
+				case '@phan-method':
 					$tagValue = $this->parseMethodTagValue($tokens);
 					break;
 
 				case '@template':
 				case '@phpstan-template':
 				case '@psalm-template':
+				case '@phan-template':
 				case '@template-covariant':
 				case '@phpstan-template-covariant':
 				case '@psalm-template-covariant':
@@ -474,6 +484,8 @@ class PhpDocParser
 
 				case '@extends':
 				case '@phpstan-extends':
+				case '@phan-extends':
+				case '@phan-inherits':
 				case '@template-extends':
 					$tagValue = $this->parseExtendsTagValue('@extends', $tokens);
 					break;
@@ -492,6 +504,7 @@ class PhpDocParser
 
 				case '@phpstan-type':
 				case '@psalm-type':
+				case '@phan-type':
 					$tagValue = $this->parseTypeAliasTagValue($tokens);
 					break;
 
@@ -506,6 +519,9 @@ class PhpDocParser
 				case '@psalm-assert':
 				case '@psalm-assert-if-true':
 				case '@psalm-assert-if-false':
+				case '@phan-assert':
+				case '@phan-assert-if-true':
+				case '@phan-assert-if-false':
 					$tagValue = $this->parseAssertTagValue($tokens);
 					break;
 
@@ -1091,7 +1107,7 @@ class PhpDocParser
 		$alias = $tokens->currentTokenValue();
 		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
-		// support psalm-type syntax
+		// support phan-type/psalm-type syntax
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL);
 
 		if ($this->preserveTypeAliasesWithInvalidTypes) {


### PR DESCRIPTION
The following prefixes are added:

* `@phan-assert`
* `@phan-assert-if-false`
* `@phan-assert-if-true`
* `@phan-extends`
* `@phan-inherits`
* `@phan-method`
* `@phan-mixin`
* `@phan-param`
* `@phan-property`
* `@phan-property-read`
* `@phan-property-write`
* `@phan-real-return`
* `@phan-return`
* `@phan-template`
* `@phan-type`
* `@phan-var`

No changes to any of the parsing were made, as the syntaxes seem to match what's already done for the existing unprefixed tags and/or the existing `@psalm-` and `@phpstan-` prefixed tags.