### PR TITLE
`TemplateTagValueNode` name cannot be empty string

### DIFF
--- a/src/Ast/PhpDoc/TemplateTagValueNode.php
+++ b/src/Ast/PhpDoc/TemplateTagValueNode.php
@@ -11,7 +11,7 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 
 	use NodeAttributes;
 
-	/** @var string */
+	/** @var non-empty-string */
 	public $name;
 
 	/** @var TypeNode|null */
@@ -23,6 +23,9 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 	/** @var string (may be empty) */
 	public $description;
 
+	/**
+	 * @param non-empty-string $name
+	 */
 	public function __construct(string $name, ?TypeNode $bound, string $description, ?TypeNode $default = null)
 	{
 		$this->name = $name;

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -510,6 +510,10 @@ class TypeParser
 			$description = '';
 		}
 
+		if ($name === '') {
+			throw new LogicException('Template tag name cannot be empty.');
+		}
+
 		return new Ast\PhpDoc\TemplateTagValueNode($name, $bound, $description, $default);
 	}
 

--- a/tests/PHPStan/Printer/PrinterTest.php
+++ b/tests/PHPStan/Printer/PrinterTest.php
@@ -1792,7 +1792,7 @@ class PrinterTest extends TestCase
 	}
 
 	/**
-	 * @return iterable<list{TypeNode, string}>
+	 * @return iterable<array{TypeNode, string}>
 	 */
 	public function dataPrintType(): iterable
 	{
@@ -1905,7 +1905,7 @@ class PrinterTest extends TestCase
 	}
 
 	/**
-	 * @return iterable<list{PhpDocNode, string}>
+	 * @return iterable<array{PhpDocNode, string}>
 	 */
 	public function dataPrintPhpDocNode(): iterable
 	{


### PR DESCRIPTION
required for https://github.com/phpstan/phpstan-src/pull/3013#discussion_r1564724373