### PR TITLE
Update roave/backward-compatibility-check

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "7.4"
+          php-version: "8.3"
 
       - name: "Install dependencies"
         run: "composer install --no-dev --no-interaction --no-progress --no-suggest"

--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -30,9 +30,6 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-dev --no-interaction --no-progress --no-suggest"
 
-      - name: "allow composer plugins"
-        run: "composer config --no-plugins --global allow-plugins.ocramius/package-versions true"
-
       - name: "Install BackwardCompatibilityCheck"
         run: "composer global require --dev roave/backward-compatibility-check"
 

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,7 @@
 		"platform": {
 			"php": "7.4.6"
 		},
-		"sort-packages": true,
-		"allow-plugins": {
-			"phpstan/extension-installer": true
-		}
+		"sort-packages": true
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
 		"platform": {
 			"php": "7.4.6"
 		},
-		"sort-packages": true
+		"sort-packages": true,
+		"allow-plugins": {
+			"phpstan/extension-installer": true
+		}
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
fixes a warning in CI

<img width="1100" alt="grafik" src="https://github.com/user-attachments/assets/18bf63d1-526c-49f6-883a-8564252bf0e7">


