### PR TITLE
PhpDocParser: support template type lower bounds

### DIFF
--- a/doc/grammars/type.abnf
+++ b/doc/grammars/type.abnf
@@ -41,7 +41,7 @@ CallableTemplate
 	= TokenAngleBracketOpen CallableTemplateArgument *(TokenComma CallableTemplateArgument) TokenAngleBracketClose
 
 CallableTemplateArgument
-    = TokenIdentifier [1*ByteHorizontalWs TokenOf Type]
+    = TokenIdentifier [1*ByteHorizontalWs TokenOf Type] [1*ByteHorizontalWs TokenSuper Type] ["=" Type]
 
 CallableParameters
 	= CallableParameter *(TokenComma CallableParameter)
@@ -200,6 +200,9 @@ TokenNot
 
 TokenOf
 	= %s"of" 1*ByteHorizontalWs
+
+TokenSuper
+	= %s"super" 1*ByteHorizontalWs
 
 TokenContravariant
     = %s"contravariant" 1*ByteHorizontalWs

--- a/src/Ast/PhpDoc/TemplateTagValueNode.php
+++ b/src/Ast/PhpDoc/TemplateTagValueNode.php
@@ -18,6 +18,9 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 	public $bound;
 
 	/** @var TypeNode|null */
+	public $lowerBound;
+
+	/** @var TypeNode|null */
 	public $default;
 
 	/** @var string (may be empty) */
@@ -26,10 +29,11 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 	/**
 	 * @param non-empty-string $name
 	 */
-	public function __construct(string $name, ?TypeNode $bound, string $description, ?TypeNode $default = null)
+	public function __construct(string $name, ?TypeNode $bound, string $description, ?TypeNode $default = null, ?TypeNode $lowerBound = null)
 	{
 		$this->name = $name;
 		$this->bound = $bound;
+		$this->lowerBound = $lowerBound;
 		$this->default = $default;
 		$this->description = $description;
 	}
@@ -37,9 +41,10 @@ class TemplateTagValueNode implements PhpDocTagValueNode
 
 	public function __toString(): string
 	{
-		$bound = $this->bound !== null ? " of {$this->bound}" : '';
+		$upperBound = $this->bound !== null ? " of {$this->bound}" : '';
+		$lowerBound = $this->lowerBound !== null ? " super {$this->lowerBound}" : '';
 		$default = $this->default !== null ? " = {$this->default}" : '';
-		return trim("{$this->name}{$bound}{$default} {$this->description}");
+		return trim("{$this->name}{$upperBound}{$lowerBound}{$default} {$this->description}");
 	}
 
 }

--- a/src/Parser/TypeParser.php
+++ b/src/Parser/TypeParser.php
@@ -491,11 +491,14 @@ class TypeParser
 		$name = $tokens->currentTokenValue();
 		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
-		if ($tokens->tryConsumeTokenValue('of') || $tokens->tryConsumeTokenValue('as')) {
-			$bound = $this->parse($tokens);
+		$upperBound = $lowerBound = null;
 
-		} else {
-			$bound = null;
+		if ($tokens->tryConsumeTokenValue('of') || $tokens->tryConsumeTokenValue('as')) {
+			$upperBound = $this->parse($tokens);
+		}
+
+		if ($tokens->tryConsumeTokenValue('super')) {
+			$lowerBound = $this->parse($tokens);
 		}
 
 		if ($tokens->tryConsumeTokenValue('=')) {
@@ -514,7 +517,7 @@ class TypeParser
 			throw new LogicException('Template tag name cannot be empty.');
 		}
 
-		return new Ast\PhpDoc\TemplateTagValueNode($name, $bound, $description, $default);
+		return new Ast\PhpDoc\TemplateTagValueNode($name, $upperBound, $description, $default, $lowerBound);
 	}
 
 

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -335,9 +335,10 @@ final class Printer
 			return trim($type . ' ' . $node->description);
 		}
 		if ($node instanceof TemplateTagValueNode) {
-			$bound = $node->bound !== null ? ' of ' . $this->printType($node->bound) : '';
+			$upperBound = $node->bound !== null ? ' of ' . $this->printType($node->bound) : '';
+			$lowerBound = $node->lowerBound !== null ? ' super ' . $this->printType($node->lowerBound) : '';
 			$default = $node->default !== null ? ' = ' . $this->printType($node->default) : '';
-			return trim("{$node->name}{$bound}{$default} {$node->description}");
+			return trim("{$node->name}{$upperBound}{$lowerBound}{$default} {$node->description}");
 		}
 		if ($node instanceof ThrowsTagValueNode) {
 			$type = $this->printType($node->type);

--- a/tests/PHPStan/Ast/ToString/PhpDocToStringTest.php
+++ b/tests/PHPStan/Ast/ToString/PhpDocToStringTest.php
@@ -155,12 +155,15 @@ class PhpDocToStringTest extends TestCase
 		$baz = new IdentifierTypeNode('Foo\\Baz');
 
 		yield from [
-			['TValue', new TemplateTagValueNode('TValue', null, '', null)],
-			['TValue of Foo\\Bar', new TemplateTagValueNode('TValue', $bar, '', null)],
+			['TValue', new TemplateTagValueNode('TValue', null, '')],
+			['TValue of Foo\\Bar', new TemplateTagValueNode('TValue', $bar, '')],
+			['TValue super Foo\\Bar', new TemplateTagValueNode('TValue', null, '', null, $bar)],
 			['TValue = Foo\\Bar', new TemplateTagValueNode('TValue', null, '', $bar)],
 			['TValue of Foo\\Bar = Foo\\Baz', new TemplateTagValueNode('TValue', $bar, '', $baz)],
-			['TValue Description.', new TemplateTagValueNode('TValue', null, 'Description.', null)],
+			['TValue Description.', new TemplateTagValueNode('TValue', null, 'Description.')],
 			['TValue of Foo\\Bar = Foo\\Baz Description.', new TemplateTagValueNode('TValue', $bar, 'Description.', $baz)],
+			['TValue super Foo\\Bar = Foo\\Baz Description.', new TemplateTagValueNode('TValue', null, 'Description.', $baz, $bar)],
+			['TValue of Foo\\Bar super Foo\\Baz Description.', new TemplateTagValueNode('TValue', $bar, 'Description.', null, $baz)],
 		];
 	}
 

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -3986,7 +3986,7 @@ some text in the middle'
 		];
 
 		yield [
-			'OK with bound and description',
+			'OK with upper bound and description',
 			'/** @template T of DateTime the value type */',
 			new PhpDocNode([
 				new PhpDocTagNode(
@@ -4001,22 +4001,41 @@ some text in the middle'
 		];
 
 		yield [
-			'OK with bound and description',
-			'/** @template T as DateTime the value type */',
+			'OK with lower bound and description',
+			'/** @template T super DateTimeImmutable the value type */',
 			new PhpDocNode([
 				new PhpDocTagNode(
 					'@template',
 					new TemplateTagValueNode(
 						'T',
-						new IdentifierTypeNode('DateTime'),
-						'the value type'
+						null,
+						'the value type',
+						null,
+						new IdentifierTypeNode('DateTimeImmutable')
 					)
 				),
 			]),
 		];
 
 		yield [
-			'invalid without bound and description',
+			'OK with both bounds and description',
+			'/** @template T of DateTimeInterface super DateTimeImmutable the value type */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@template',
+					new TemplateTagValueNode(
+						'T',
+						new IdentifierTypeNode('DateTimeInterface'),
+						'the value type',
+						null,
+						new IdentifierTypeNode('DateTimeImmutable')
+					)
+				),
+			]),
+		];
+
+		yield [
+			'invalid without bounds and description',
 			'/** @template */',
 			new PhpDocNode([
 				new PhpDocTagNode(

--- a/tests/PHPStan/Printer/PrinterTest.php
+++ b/tests/PHPStan/Printer/PrinterTest.php
@@ -947,6 +947,12 @@ class PrinterTest extends TestCase
 			$addTemplateTagBound,
 		];
 
+		yield [
+			'/** @template T super string */',
+			'/** @template T of int super string */',
+			$addTemplateTagBound,
+		];
+
 		$removeTemplateTagBound = new class extends AbstractNodeVisitor {
 
 			public function enterNode(Node $node)
@@ -964,6 +970,56 @@ class PrinterTest extends TestCase
 			'/** @template T of int */',
 			'/** @template T */',
 			$removeTemplateTagBound,
+		];
+
+		$addTemplateTagLowerBound = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof TemplateTagValueNode) {
+					$node->lowerBound = new IdentifierTypeNode('int');
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			'/** @template T */',
+			'/** @template T super int */',
+			$addTemplateTagLowerBound,
+		];
+
+		yield [
+			'/** @template T super string */',
+			'/** @template T super int */',
+			$addTemplateTagLowerBound,
+		];
+
+		yield [
+			'/** @template T of string */',
+			'/** @template T of string super int */',
+			$addTemplateTagLowerBound,
+		];
+
+		$removeTemplateTagLowerBound = new class extends AbstractNodeVisitor {
+
+			public function enterNode(Node $node)
+			{
+				if ($node instanceof TemplateTagValueNode) {
+					$node->lowerBound = null;
+				}
+
+				return $node;
+			}
+
+		};
+
+		yield [
+			'/** @template T super int */',
+			'/** @template T */',
+			$removeTemplateTagLowerBound,
 		];
 
 		$addKeyNameToArrayShapeItemNode = new class extends AbstractNodeVisitor {


### PR DESCRIPTION
I'd like to take a shot at template type lower bounds (phpstan/phpstan#5179). This PR adds support for parsing lower bounds.

As I've reasoned in https://github.com/phpstan/phpstan/issues/5179#issuecomment-1529134067: while I don't think it's particularly useful, the implementation that I envision in phpstan/phpstan-src will be able to account for a template having both bounds, regardless of whether it's allowed in the parser or not. Thus, I don't see any technical reason _not_ to allow it.