### PR TITLE
Test inline `@link` in Lexer

### DIFF
--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -6989,6 +6989,23 @@ Finder::findFiles('*.php')
 	}
 
 	/**
+	 * @dataProvider provideLexerData
+	 */
+	public function testClosingBraceInlineTag(
+		string $input,
+		array $expectedTokens,
+	): void {
+		$tokens = new TokenIterator($this->lexer->tokenize($input));
+		$this->assertEquals($expectedTokens, array_map(
+			fn ($token) => [
+				$token[Lexer::TYPE_OFFSET],
+				$token[Lexer::VALUE_OFFSET],
+			],
+			$tokens->getTokens(),
+		));
+	}
+
+	/**
 	 * @return array<mixed>
 	 */
 	public function dataLinesAndIndexes(): iterable
@@ -7662,6 +7679,32 @@ Finder::findFiles('*.php')
 				new PhpDocTextNode(''),
 			]),
 		];
+	}
+
+	public function provideLexerData(): Iterator
+	{
+		yield ['{@link https://example.com}', [
+			[Lexer::TOKEN_OPEN_CURLY_BRACKET, '{'],
+			[Lexer::TOKEN_PHPDOC_TAG, '@link'],
+			[Lexer::TOKEN_HORIZONTAL_WS, ' '],
+			[Lexer::TOKEN_IDENTIFIER, 'https'],
+			[Lexer::TOKEN_COLON, ':'],
+			[Lexer::TOKEN_OTHER, '//example.com'],
+			[Lexer::TOKEN_CLOSE_CURLY_BRACKET, '}'],
+			[Lexer::TOKEN_END, ''],
+		]];
+
+		yield ['{@link https://example.com }', [
+			[Lexer::TOKEN_OPEN_CURLY_BRACKET, '{'],
+			[Lexer::TOKEN_PHPDOC_TAG, '@link'],
+			[Lexer::TOKEN_HORIZONTAL_WS, ' '],
+			[Lexer::TOKEN_IDENTIFIER, 'https'],
+			[Lexer::TOKEN_COLON, ':'],
+			[Lexer::TOKEN_OTHER, '//example.com'],
+			[Lexer::TOKEN_HORIZONTAL_WS, ' '],
+			[Lexer::TOKEN_CLOSE_CURLY_BRACKET, '}'],
+			[Lexer::TOKEN_END, ''],
+		]];
 	}
 
 	/**


### PR DESCRIPTION
This is a followup to #261. Whilst the parsing of the tags themselves is correct in phpstan, Rector uses the PHPStan Lexer to tokenize the values. It seems that the tokenisation bundles the closing curly brace into the previous text content unless there is whitespace between them.

This test demonstrates that issue.

This issue is also present for opening/closing angle brackets, and parens. It seems that the OTHER token is too greedy.

It may be that this is the intended behaviour of the Lexer but I haven't been able to find any documentation or information to confirm either way.

https://github.com/rectorphp/rector/issues/8977 has additional info on the issue and how it is encountered.