### PR TITLE
Update Slevomat CS ref to fix flaky workflow

### DIFF
--- a/.github/workflows/test-slevomat-coding-standard.yml
+++ b/.github/workflows/test-slevomat-coding-standard.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           repository: slevomat/coding-standard
           path: slevomat-cs
-          ref: 88602f9ae5450a933133108d052eeb2edee0a4b7
+          ref: ae7325d76167f02e3b20b0ad19122dcf472188e4
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
Update the Slevomat Coding Standard checkout ref to `ae7325d76167f02e3b20b0ad19122dcf472188e4` in the test workflow.

Closes #290

Generated with [Claude Code](https://claude.ai/code)