### PR TITLE
Run the tests written for `@pure-unless-parameter-passed`

### DIFF
--- a/src/Ast/PhpDoc/PureUnlessParameterIsPassedTagValueNode.php
+++ b/src/Ast/PhpDoc/PureUnlessParameterIsPassedTagValueNode.php
@@ -26,4 +26,18 @@ class PureUnlessParameterIsPassedTagValueNode implements PhpDocTagValueNode
 		return trim("{$this->parameterName} {$this->description}");
 	}
 
+	/**
+	 * @param array<string, mixed> $properties
+	 */
+	public static function __set_state(array $properties): self
+	{
+		$instance = new self($properties['parameterName'], $properties['description']);
+		if (isset($properties['attributes'])) {
+			foreach ($properties['attributes'] as $key => $value) {
+				$instance->setAttribute($key, $value);
+			}
+		}
+		return $instance;
+	}
+
 }

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -104,6 +104,7 @@ class PhpDocParserTest extends TestCase
 	 * @dataProvider provideTypelessParamTagsData
 	 * @dataProvider provideParamClosureThisTagsData
 	 * @dataProvider providePureUnlessCallableIsImpureTagsData
+	 * @dataProvider providePureUnlessParameterIsPassedTagsData
 	 * @dataProvider provideVarTagsData
 	 * @dataProvider provideReturnTagsData
 	 * @dataProvider provideThrowsTagsData


### PR DESCRIPTION
`providePureUnlessParameterIsPassedTagsData` was written for `@pure-unless-parameter-passed` in fb19eed, but was never named among the `@dataProvider` lines `testParse` is run with. Its two cases had never run.

They do not pass. `PureUnlessParameterIsPassedTagValueNode` is the one concrete node of `src/Ast/PhpDoc` without a `__set_state()`, and `testParse` writes every node out with `var_export()` and reads it back:

```
Error: Call to undefined method PHPStan\PhpDocParser\Ast\PhpDoc\PureUnlessParameterIsPassedTagValueNode::__set_state()
```

So this names the provider and gives the node the `__set_state()` its siblings have — `PureUnlessCallableIsImpureTagValueNode`'s, word for word.

Found while writing the grammar-sync test of #309, which reads the inputs of every other test out of the providers they are written with, and so walks over providers nothing else runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GavWEzia8ZVUYEe6JEde9i
