### PR TITLE
Add large payload bench

### DIFF
--- a/tools/phplrt/large-payload-bench.php
+++ b/tools/phplrt/large-payload-bench.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Phplrt\Source\StringSource;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
+
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
+
+// PHPLRT
+$compile = new Phplrt\Compiler\Compiler()
+    ->load(new \SplFileObject(__DIR__ . '/../../doc/grammars/type.pp3'))
+    ->generate()
+        ->save(__DIR__ . '/parser.php');
+
+$phplrt = require __DIR__ . '/parser.php';
+
+// PHPStan
+$config = new ParserConfig([]);
+$phpstanLexer = new Lexer($config);
+$phpstanParser = new TypeParser($config, new ConstExprParser($config));
+
+
+// -------------
+
+const ITS = 10;
+
+$sample = $sampleType = 'array<string, array<int, iterable<int, Example\Class>>>';
+for ($i = 0; $i < 1000; ++$i) {
+    $sample .= '|' . $sampleType;
+}
+
+// phplrt4
+$before = microtime(true);
+
+for ($i = 0; $i < ITS; ++$i) {
+    $phplrt->parse(new StringSource($sample));
+}
+
+
+echo 'phplrt4: ' . number_format((microtime(true) - $before) * 1000, 3) . "ms\n";
+
+// phpstan 2.3
+$before = \microtime(true);
+
+for ($i = 0; $i < ITS; ++$i) {
+    $phpstanParser->parse(new TokenIterator($phpstanLexer->tokenize($sample)));
+}
+
+echo 'phpstan: ' . number_format((microtime(true) - $before) * 1000, 3) . "ms\n";


### PR DESCRIPTION
Please note that the phplrt implementation doesn't build an AST, as I didn't want to touch original grammar, which adds about 10% to the speed.

The PR only highlights regression and instability in the PHPStan type parser with increasing input payload size, as @ondrejmirtes requested.


Results (~14x times slower):
```
phplrt4: 961.932ms
phpstan: 13,201.727ms
```

P.S. In case of size increase (~28x times slower):
```
// - for ($i = 0; $i < 1000; ++$i) {
// + for ($i = 0; $i < 2000; ++$i) {

phplrt4: 1,941.367ms
phpstan: 54,044.375ms
```

etc.