### PR TITLE
Lexer: return a struct-of-arrays TokenList (BC break, ~26% faster lexing)

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -93,10 +93,6 @@ class Lexer
 		self::TOKEN_WILDCARD => '*',
 	];
 
-	public const VALUE_OFFSET = 0;
-	public const TYPE_OFFSET = 1;
-	public const LINE_OFFSET = 2;
-
 	private ParserConfig $config; // @phpstan-ignore property.onlyWritten
 
 	private ?string $regexp = null;
@@ -106,10 +102,7 @@ class Lexer
 		$this->config = $config;
 	}
 
-	/**
-	 * @return list<array{string, int, int}>
-	 */
-	public function tokenize(string $s): array
+	public function tokenize(string $s): TokenList
 	{
 		if ($this->regexp === null) {
 			$this->regexp = $this->generateRegexp();
@@ -123,16 +116,18 @@ class Lexer
 
 		$values = $matches[0];
 		if ($values === []) {
-			return [['', self::TOKEN_END, 1]];
+			return new TokenList([''], [self::TOKEN_END], [1]);
 		}
 
-		$marks = $matches['MARK'];
-
-		$tokens = [];
+		// $matches[0] is already the values array of the TokenList, so the
+		// values never get copied out of it token by token.
+		$types = [];
+		$lines = [];
 		$line = 1;
-		foreach ($values as $i => $value) {
-			$type = (int) $marks[$i];
-			$tokens[] = [$value, $type, $line];
+		foreach ($matches['MARK'] as $mark) {
+			$type = (int) $mark;
+			$types[] = $type;
+			$lines[] = $line;
 			if ($type !== self::TOKEN_PHPDOC_EOL) {
 				continue;
 			}
@@ -140,9 +135,11 @@ class Lexer
 			$line++;
 		}
 
-		$tokens[] = ['', self::TOKEN_END, $line];
+		$values[] = '';
+		$types[] = self::TOKEN_END;
+		$lines[] = $line;
 
-		return $tokens;
+		return new TokenList($values, $types, $lines);
 	}
 
 	private function generateRegexp(): string

--- a/src/Lexer/TokenList.php
+++ b/src/Lexer/TokenList.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Lexer;
+
+use Countable;
+use function count;
+
+/**
+ * Tokens in a struct-of-arrays layout: three parallel packed arrays instead of
+ * one array (or object) per token.
+ */
+final class TokenList implements Countable
+{
+
+	/** @var list<string> */
+	public array $values;
+
+	/** @var list<int> */
+	public array $types;
+
+	/** @var list<int> */
+	public array $lines;
+
+	/** @var int<0, max> */
+	public int $count;
+
+	/**
+	 * @param list<string> $values
+	 * @param list<int> $types
+	 * @param list<int> $lines
+	 */
+	public function __construct(array $values, array $types, array $lines)
+	{
+		$this->values = $values;
+		$this->types = $types;
+		$this->lines = $lines;
+		$this->count = count($values);
+	}
+
+	/**
+	 * Only so that code written against the array this replaces keeps working.
+	 * Read the $count property directly in hot paths -- reading a property is
+	 * cheaper than the call this makes.
+	 */
+	public function count(): int
+	{
+		return $this->count;
+	}
+
+}

--- a/src/Parser/TokenIterator.php
+++ b/src/Parser/TokenIterator.php
@@ -5,9 +5,9 @@ namespace PHPStan\PhpDocParser\Parser;
 use LogicException;
 use PHPStan\PhpDocParser\Ast\Comment;
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Lexer\TokenList;
 use function array_pop;
 use function assert;
-use function count;
 use function in_array;
 use function strlen;
 use function substr;
@@ -15,8 +15,18 @@ use function substr;
 class TokenIterator
 {
 
-	/** @var list<array{string, int, int}> */
-	private array $tokens;
+	private TokenList $tokens;
+
+	/** @var list<string> */
+	private array $values;
+
+	/** @var list<int> */
+	private array $types;
+
+	/** @var list<int> */
+	private array $lines;
+
+	private int $count;
 
 	private int $index;
 
@@ -31,34 +41,32 @@ class TokenIterator
 
 	private ?string $newline = null;
 
-	/**
-	 * @param list<array{string, int, int}> $tokens
-	 */
-	public function __construct(array $tokens, int $index = 0)
+	public function __construct(TokenList $tokens, int $index = 0)
 	{
 		$this->tokens = $tokens;
+		$this->values = $tokens->values;
+		$this->types = $tokens->types;
+		$this->lines = $tokens->lines;
+		$this->count = $tokens->count;
 		$this->index = $index;
 
 		$this->skipIrrelevantTokens();
 	}
 
-	/**
-	 * @return list<array{string, int, int}>
-	 */
-	public function getTokens(): array
+	public function getTokens(): TokenList
 	{
 		return $this->tokens;
 	}
 
 	public function getContentBetween(int $startPos, int $endPos): string
 	{
-		if ($startPos < 0 || $endPos > count($this->tokens)) {
+		if ($startPos < 0 || $endPos > $this->count) {
 			throw new LogicException();
 		}
 
 		$content = '';
 		for ($i = $startPos; $i < $endPos; $i++) {
-			$content .= $this->tokens[$i][Lexer::VALUE_OFFSET];
+			$content .= $this->values[$i];
 		}
 
 		return $content;
@@ -66,24 +74,24 @@ class TokenIterator
 
 	public function getTokenCount(): int
 	{
-		return count($this->tokens);
+		return $this->count;
 	}
 
 	public function currentTokenValue(): string
 	{
-		return $this->tokens[$this->index][Lexer::VALUE_OFFSET];
+		return $this->values[$this->index];
 	}
 
 	public function currentTokenType(): int
 	{
-		return $this->tokens[$this->index][Lexer::TYPE_OFFSET];
+		return $this->types[$this->index];
 	}
 
 	public function currentTokenOffset(): int
 	{
 		$offset = 0;
 		for ($i = 0; $i < $this->index; $i++) {
-			$offset += strlen($this->tokens[$i][Lexer::VALUE_OFFSET]);
+			$offset += strlen($this->values[$i]);
 		}
 
 		return $offset;
@@ -91,7 +99,7 @@ class TokenIterator
 
 	public function currentTokenLine(): int
 	{
-		return $this->tokens[$this->index][Lexer::LINE_OFFSET];
+		return $this->lines[$this->index];
 	}
 
 	public function currentTokenIndex(): int
@@ -103,8 +111,8 @@ class TokenIterator
 	{
 		$endIndex = $this->currentTokenIndex();
 		$endIndex--;
-		while (in_array($this->tokens[$endIndex][Lexer::TYPE_OFFSET], $this->skippedTokenTypes, true)) {
-			if (!isset($this->tokens[$endIndex - 1])) {
+		while (in_array($this->types[$endIndex], $this->skippedTokenTypes, true)) {
+			if ($endIndex - 1 < 0) {
 				break;
 			}
 			$endIndex--;
@@ -115,17 +123,17 @@ class TokenIterator
 
 	public function isCurrentTokenValue(string $tokenValue): bool
 	{
-		return $this->tokens[$this->index][Lexer::VALUE_OFFSET] === $tokenValue;
+		return $this->values[$this->index] === $tokenValue;
 	}
 
 	public function isCurrentTokenType(int ...$tokenType): bool
 	{
-		return in_array($this->tokens[$this->index][Lexer::TYPE_OFFSET], $tokenType, true);
+		return in_array($this->types[$this->index], $tokenType, true);
 	}
 
 	public function isPrecededByHorizontalWhitespace(): bool
 	{
-		return ($this->tokens[$this->index - 1][Lexer::TYPE_OFFSET] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
+		return ($this->types[$this->index - 1] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
 	}
 
 	/**
@@ -133,7 +141,7 @@ class TokenIterator
 	 */
 	public function consumeTokenType(int $tokenType): void
 	{
-		if ($this->tokens[$this->index][Lexer::TYPE_OFFSET] !== $tokenType) {
+		if ($this->types[$this->index] !== $tokenType) {
 			$this->throwError($tokenType);
 		}
 
@@ -151,7 +159,7 @@ class TokenIterator
 	 */
 	public function consumeTokenValue(int $tokenType, string $tokenValue): void
 	{
-		if ($this->tokens[$this->index][Lexer::TYPE_OFFSET] !== $tokenType || $this->tokens[$this->index][Lexer::VALUE_OFFSET] !== $tokenValue) {
+		if ($this->types[$this->index] !== $tokenType || $this->values[$this->index] !== $tokenValue) {
 			$this->throwError($tokenType, $tokenValue);
 		}
 
@@ -161,7 +169,7 @@ class TokenIterator
 	/** @phpstan-impure */
 	public function tryConsumeTokenValue(string $tokenValue): bool
 	{
-		if ($this->tokens[$this->index][Lexer::VALUE_OFFSET] !== $tokenValue) {
+		if ($this->values[$this->index] !== $tokenValue) {
 			return false;
 		}
 
@@ -183,7 +191,7 @@ class TokenIterator
 	/** @phpstan-impure */
 	public function tryConsumeTokenType(int $tokenType): bool
 	{
-		if ($this->tokens[$this->index][Lexer::TYPE_OFFSET] !== $tokenType) {
+		if ($this->types[$this->index] !== $tokenType) {
 			return false;
 		}
 
@@ -246,8 +254,8 @@ class TokenIterator
 
 	public function getSkippedHorizontalWhiteSpaceIfAny(): string
 	{
-		if ($this->index > 0 && $this->tokens[$this->index - 1][Lexer::TYPE_OFFSET] === Lexer::TOKEN_HORIZONTAL_WS) {
-			return $this->tokens[$this->index - 1][Lexer::VALUE_OFFSET];
+		if ($this->index > 0 && $this->types[$this->index - 1] === Lexer::TOKEN_HORIZONTAL_WS) {
+			return $this->values[$this->index - 1];
 		}
 
 		return '';
@@ -257,8 +265,8 @@ class TokenIterator
 	public function joinUntil(int ...$tokenType): string
 	{
 		$s = '';
-		while (!in_array($this->tokens[$this->index][Lexer::TYPE_OFFSET], $tokenType, true)) {
-			$s .= $this->tokens[$this->index++][Lexer::VALUE_OFFSET];
+		while (!in_array($this->types[$this->index], $tokenType, true)) {
+			$s .= $this->values[$this->index++];
 		}
 		return $s;
 	}
@@ -271,12 +279,12 @@ class TokenIterator
 
 	private function skipIrrelevantTokens(): void
 	{
-		if (!isset($this->tokens[$this->index])) {
+		if ($this->index >= $this->count) {
 			return;
 		}
 
-		while (in_array($this->tokens[$this->index][Lexer::TYPE_OFFSET], $this->skippedTokenTypes, true)) {
-			if (!isset($this->tokens[$this->index + 1])) {
+		while (in_array($this->types[$this->index], $this->skippedTokenTypes, true)) {
+			if ($this->index + 1 >= $this->count) {
 				break;
 			}
 			$this->index++;
@@ -296,8 +304,7 @@ class TokenIterator
 	/** @phpstan-impure */
 	public function forwardToTheEnd(): void
 	{
-		$lastToken = count($this->tokens) - 1;
-		$this->index = $lastToken;
+		$this->index = $this->count - 1;
 	}
 
 	public function pushSavePoint(): void
@@ -339,11 +346,10 @@ class TokenIterator
 	 */
 	public function hasTokenImmediatelyBefore(int $pos, int $expectedTokenType): bool
 	{
-		$tokens = $this->tokens;
+		$types = $this->types;
 		$pos--;
 		for (; $pos >= 0; $pos--) {
-			$token = $tokens[$pos];
-			$type = $token[Lexer::TYPE_OFFSET];
+			$type = $types[$pos];
 			if ($type === $expectedTokenType) {
 				return true;
 			}
@@ -364,11 +370,10 @@ class TokenIterator
 	 */
 	public function hasTokenImmediatelyAfter(int $pos, int $expectedTokenType): bool
 	{
-		$tokens = $this->tokens;
+		$types = $this->types;
 		$pos++;
-		for ($c = count($tokens); $pos < $c; $pos++) {
-			$token = $tokens[$pos];
-			$type = $token[Lexer::TYPE_OFFSET];
+		for ($c = $this->count; $pos < $c; $pos++) {
+			$type = $types[$pos];
 			if ($type === $expectedTokenType) {
 				return true;
 			}

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -735,12 +735,12 @@ final class Printer
 				if ($i === 0) {
 					// If we're removing from the start, keep the tokens before the node and drop those after it,
 					// instead of the other way around.
-					$originalTokensArray = $originalTokens->getTokens();
+					$originalTokensList = $originalTokens->getTokens();
 					for ($j = $tokenIndex; $j < $itemStartPos; $j++) {
-						if ($originalTokensArray[$j][Lexer::TYPE_OFFSET] === Lexer::TOKEN_PHPDOC_EOL) {
+						if ($originalTokensList->types[$j] === Lexer::TOKEN_PHPDOC_EOL) {
 							break;
 						}
-						$result .= $originalTokensArray[$j][Lexer::VALUE_OFFSET];
+						$result .= $originalTokensList->values[$j];
 					}
 				}
 
@@ -755,10 +755,10 @@ final class Printer
 
 			[$findToken, $extraLeft, $extraRight] = $this->emptyListInsertionMap[$mapKey];
 			if ($findToken !== null) {
-				$originalTokensArray = $originalTokens->getTokens();
-				for (; $tokenIndex < count($originalTokensArray); $tokenIndex++) {
-					$result .= $originalTokensArray[$tokenIndex][Lexer::VALUE_OFFSET];
-					if ($originalTokensArray[$tokenIndex][Lexer::VALUE_OFFSET] !== $findToken) {
+				$originalTokensList = $originalTokens->getTokens();
+				for (; $tokenIndex < $originalTokensList->count; $tokenIndex++) {
+					$result .= $originalTokensList->values[$tokenIndex];
+					if ($originalTokensList->values[$tokenIndex] !== $findToken) {
 						continue;
 					}
 

--- a/tests/PHPStan/Lexer/LexerTest.php
+++ b/tests/PHPStan/Lexer/LexerTest.php
@@ -6,6 +6,7 @@ use PHPStan\PhpDocParser\ParserConfig;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use function array_keys;
+use function count;
 use function preg_match_all;
 use const PHP_VERSION_ID;
 
@@ -38,6 +39,19 @@ class LexerTest extends TestCase
 		preg_match_all($regexp, $subject, $matches);
 
 		self::assertSame([0, 'MARK'], array_keys($matches));
+	}
+
+	/**
+	 * tokenize() used to return an array, so count() on its result has to keep
+	 * saying how many tokens there are.
+	 */
+	public function testTokenListIsCountable(): void
+	{
+		$lexer = new Lexer(new ParserConfig([]));
+		$tokens = $lexer->tokenize('/** @param int $a */');
+
+		self::assertCount($tokens->count, $tokens);
+		self::assertCount(count($tokens->values), $tokens);
 	}
 
 }

--- a/tests/PHPStan/Parser/TypeParserTest.php
+++ b/tests/PHPStan/Parser/TypeParserTest.php
@@ -3539,7 +3539,7 @@ class TypeParserTest extends TestCase
 
 			$content = '';
 			for ($i = $startIndex; $i <= $endIndex; $i++) {
-				$content .= $tokensArray[$i][Lexer::VALUE_OFFSET];
+				$content .= $tokensArray->values[$i];
 			}
 			$this->assertSame($expectedContent, $content);
 		}

--- a/tools/phplrt/Fuzzer/TokenStream.php
+++ b/tools/phplrt/Fuzzer/TokenStream.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace PHPStan\PhpDocParser\Tools\Fuzzer;
 
 use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Lexer\TokenList;
 use Phplrt\Contracts\Lexer\Channel;
 use Phplrt\Contracts\Lexer\ChannelInterface;
 use Phplrt\Contracts\Lexer\LexerInterface;
@@ -280,17 +281,16 @@ final class TokenStream
     }
 
     /**
-     * @param list<array{string, int, int}> $tokens
      * @return list<Token>
      */
-    public function create(array $tokens): array
+    public function create(TokenList $tokens): array
     {
         $result = [];
         $offset = 0;
+        $types = $tokens->types;
 
-        foreach ($tokens as $index => $token) {
-            $type = $token[Lexer::TYPE_OFFSET];
-            $value = $token[Lexer::VALUE_OFFSET];
+        foreach ($tokens->values as $index => $value) {
+            $type = $types[$index];
 
             if ($type === Lexer::TOKEN_HORIZONTAL_WS) {
                 $offset += \strlen($value);
@@ -312,10 +312,7 @@ final class TokenStream
         return $result;
     }
 
-    /**
-     * @param list<array{string, int, int}> $tokens
-     */
-    private function identify(array $tokens, int $index, int $type, string $value): int
+    private function identify(TokenList $tokens, int $index, int $type, string $value): int
     {
         switch ($type) {
             case Lexer::TOKEN_IDENTIFIER:
@@ -338,22 +335,22 @@ final class TokenStream
                     return $this->id($tag);
                 }
 
-                return $this->id(self::isPrecededByWhitespace($tokens, $index) ? 'T_PHPDOC_TAG_WS' : 'T_PHPDOC_TAG');
+                return $this->id(self::isPrecededByWhitespace($tokens->types, $index) ? 'T_PHPDOC_TAG_WS' : 'T_PHPDOC_TAG');
 
             case Lexer::TOKEN_DOCTRINE_TAG:
-                return $this->id(self::isPrecededByWhitespace($tokens, $index) ? 'T_DOCTRINE_TAG_WS' : 'T_DOCTRINE_TAG');
+                return $this->id(self::isPrecededByWhitespace($tokens->types, $index) ? 'T_DOCTRINE_TAG_WS' : 'T_DOCTRINE_TAG');
 
             case Lexer::TOKEN_OPEN_CURLY_BRACKET:
-                return $this->id(self::isPrecededByWhitespace($tokens, $index) ? 'T_OPEN_CURLY_BRACKET_WS' : 'T_OPEN_CURLY_BRACKET');
+                return $this->id(self::isPrecededByWhitespace($tokens->types, $index) ? 'T_OPEN_CURLY_BRACKET_WS' : 'T_OPEN_CURLY_BRACKET');
 
             case Lexer::TOKEN_OPEN_PARENTHESES:
-                return $this->id(self::isPrecededByWhitespace($tokens, $index) ? 'T_OPEN_PARENTHESES_WS' : 'T_OPEN_PARENTHESES');
+                return $this->id(self::isPrecededByWhitespace($tokens->types, $index) ? 'T_OPEN_PARENTHESES_WS' : 'T_OPEN_PARENTHESES');
 
             case Lexer::TOKEN_OPEN_SQUARE_BRACKET:
-                return $this->id(self::isPrecededByWhitespace($tokens, $index) ? 'T_OPEN_SQUARE_BRACKET_WS' : 'T_OPEN_SQUARE_BRACKET');
+                return $this->id(self::isPrecededByWhitespace($tokens->types, $index) ? 'T_OPEN_SQUARE_BRACKET_WS' : 'T_OPEN_SQUARE_BRACKET');
 
             case Lexer::TOKEN_WILDCARD:
-                return $this->id(self::isFollowedByWhitespace($tokens, $index) ? 'T_WILDCARD_WS' : 'T_WILDCARD');
+                return $this->id(self::isFollowedByWhitespace($tokens->types, $index) ? 'T_WILDCARD_WS' : 'T_WILDCARD');
 
             case Lexer::TOKEN_OPEN_ANGLE_BRACKET:
                 return $this->id(self::isHtml($tokens, $index) ? 'T_OPEN_ANGLE_BRACKET_HTML' : 'T_OPEN_ANGLE_BRACKET');
@@ -364,78 +361,77 @@ final class TokenStream
     }
 
     /**
-     * @param list<array{string, int, int}> $tokens
+     * @param list<int> $types
      */
-    private static function isPrecededByWhitespace(array $tokens, int $index): bool
+    private static function isPrecededByWhitespace(array $types, int $index): bool
     {
-        return ($tokens[$index - 1][Lexer::TYPE_OFFSET] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
+        return ($types[$index - 1] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
     }
 
     /**
-     * @param list<array{string, int, int}> $tokens
+     * @param list<int> $types
      */
-    private static function isFollowedByWhitespace(array $tokens, int $index): bool
+    private static function isFollowedByWhitespace(array $types, int $index): bool
     {
-        return ($tokens[$index + 1][Lexer::TYPE_OFFSET] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
+        return ($types[$index + 1] ?? -1) === Lexer::TOKEN_HORIZONTAL_WS;
     }
 
     /**
      * Whether the "<" at the given position opens what
      * PHPStan\PhpDocParser\Parser\TypeParser::isHtml() recognizes as an HTML
      * tag, read the very same way it reads it.
-     *
-     * @param list<array{string, int, int}> $tokens
      */
-    private static function isHtml(array $tokens, int $index): bool
+    private static function isHtml(TokenList $tokens, int $index): bool
     {
-        $count = \count($tokens);
+        $count = $tokens->count;
+        $types = $tokens->types;
 
-        $index = self::skipWhitespace($tokens, $index + 1, $count);
-        if ($index >= $count || $tokens[$index][Lexer::TYPE_OFFSET] !== Lexer::TOKEN_IDENTIFIER) {
+        $index = self::skipWhitespace($types, $index + 1, $count);
+        if ($index >= $count || $types[$index] !== Lexer::TOKEN_IDENTIFIER) {
             return false;
         }
 
-        $name = $tokens[$index][Lexer::VALUE_OFFSET];
+        $name = $tokens->values[$index];
 
-        $index = self::skipWhitespace($tokens, $index + 1, $count);
-        if ($index >= $count || $tokens[$index][Lexer::TYPE_OFFSET] !== Lexer::TOKEN_CLOSE_ANGLE_BRACKET) {
+        $index = self::skipWhitespace($types, $index + 1, $count);
+        if ($index >= $count || $types[$index] !== Lexer::TOKEN_CLOSE_ANGLE_BRACKET) {
             return false;
         }
 
-        $index = self::skipWhitespace($tokens, $index + 1, $count);
+        $index = self::skipWhitespace($types, $index + 1, $count);
 
         $endTag = '</' . $name . '>';
         $length = \strlen($endTag);
 
-        while ($index < $count && $tokens[$index][Lexer::TYPE_OFFSET] !== Lexer::TOKEN_END) {
-            if ($tokens[$index][Lexer::TYPE_OFFSET] === Lexer::TOKEN_OPEN_ANGLE_BRACKET) {
-                $index = self::skipWhitespace($tokens, $index + 1, $count);
+        while ($index < $count && $types[$index] !== Lexer::TOKEN_END) {
+            if ($types[$index] === Lexer::TOKEN_OPEN_ANGLE_BRACKET) {
+                $index = self::skipWhitespace($types, $index + 1, $count);
 
-                if ($index < $count && \strpos($tokens[$index][Lexer::VALUE_OFFSET], '/' . $name . '>') !== false) {
+                if ($index < $count && \strpos($tokens->values[$index], '/' . $name . '>') !== false) {
                     return true;
                 }
             }
 
             if ($index < $count) {
-                $value = $tokens[$index][Lexer::VALUE_OFFSET];
+                $value = $tokens->values[$index];
 
                 if (\strlen($value) >= $length && \substr_compare($value, $endTag, -$length) === 0) {
                     return true;
                 }
             }
 
-            $index = self::skipWhitespace($tokens, $index + 1, $count);
+            $index = self::skipWhitespace($types, $index + 1, $count);
         }
 
         return false;
     }
 
     /**
-     * @param list<array{string, int, int}> $tokens
+     * @param list<int> $types
      */
-    private static function skipWhitespace(array $tokens, int $index, int $count): int
+    private static function skipWhitespace(array $types, int $index, int $count): int
     {
-        while ($index < $count && $tokens[$index][Lexer::TYPE_OFFSET] === Lexer::TOKEN_HORIZONTAL_WS) {
+        while ($index < $count && $types[$index] === Lexer::TOKEN_HORIZONTAL_WS) {
             $index++;
         }
 


### PR DESCRIPTION
Follow-up to #313, now merged and released as 2.3.5. Rebased onto `2.3.x`, so
this is one commit against current master. **This one is a BC break and needs a
major**, which #313 deliberately was not.

## The BC break

```php
Lexer::tokenize(string $s): array               →  : TokenList
TokenIterator::__construct(array $tokens, …)    →  (TokenList $tokens, …)
TokenIterator::getTokens(): array               →  : TokenList

Lexer::VALUE_OFFSET                             →  removed
Lexer::TYPE_OFFSET                              →  removed
Lexer::LINE_OFFSET                              →  removed
```

Those six, and nothing else — the BC checker on this PR reports exactly them.

`TokenList` holds three parallel packed arrays plus a count:

```php
final class TokenList implements Countable
{
	/** @var list<string> */  public array $values;
	/** @var list<int> */     public array $types;
	/** @var list<int> */     public array $lines;
	/** @var int<0, max> */   public int $count;

	public function count(): int;
}
```

`TokenList` implements `Countable`, so `count($tokens)` written against the
array keeps working. The `$count` property is the fast path for hot loops; the
method exists for the migration.

The three offset constants are dropped rather than left behind. They index into
a tuple that no longer exists, so keeping them would only let code compile that
cannot work — a fatal at the point of use is worse than a missing constant the
migration can grep for.

Who has to change:

- **Anything that indexes the token list itself** — `$tokens[$i][Lexer::TYPE_OFFSET]`
  becomes `$tokens->types[$i]`. This is the whole migration.
- **Anything that passes tokens straight into a `TokenIterator`** — nothing to do.
  `new TokenIterator($lexer->tokenize($s))` keeps compiling, because both ends of
  the break move together.

This repository has consumers of both kinds, which makes a good worked
example. The five `new TokenIterator($lexer->tokenize(...))` call sites needed
nothing. `tools/phplrt/Fuzzer/TokenStream` indexes tokens and is migrated here:
mostly `$tokens[$i][Lexer::TYPE_OFFSET]` → `$tokens->types[$i]`. Splitting the
tuple also let three of its helpers narrow from the whole token list to just the
types array they actually read, which is the sort of tidy-up the new shape
invites. That file is not covered by `make check`, so the grammar CI jobs caught
the migration rather than my local run — worth knowing if you go looking for
other consumers.

For calibration I also grepped phpstan-src: all five phpdoc-parser call sites
there (`PhpDocStringResolver`, `TypeStringResolver`, `InvalidPHPStanDocTagRule`,
`InvalidPhpDocTagValueRule`, `PhpDocEditor`) are the second kind and need no
edit, and nothing in it indexes a phpdoc-parser token. I could only survey the
consumers on my disk, though — you will have a far better sense of what else
reaches into the token array.

## Why

Since 2.3.5 `tokenize()` extracts the matches with `PREG_PATTERN_ORDER`, but it
still copies the values out of `$matches[0]` one at a time to build a tuple per
token. With three parallel arrays that last per-token allocation disappears:
`$matches[0]` *becomes* the values array of the `TokenList`, and only the types
and the lines are filled in a loop.

## Numbers

Same corpus as #313 — 37 150 unique docblocks, 8.38 MiB, 2 355 859 tokens — one
core, `php -n`, minimum of 15 rounds with the variants interleaved.

| | lexing | parse | bytes/token |
| --- | --- | --- | --- |
| 2.3.5 | 235 ms | 777 ms | 269 |
| **+ TokenList** | **175 ms (−26%)** | **671 ms (−14%)** | **124 (−54%)** |

With opcache and the tracing JIT: −28% lexing and −18% parse, so the gain holds
up there too.

For scale against the release before #313 landed: in a single interleaved run of
all three, 2.3.4 lexed the same corpus in 416 ms and parsed it in 1002 ms
against 2.3.5's 249 ms / 822 ms and this PR's 184 ms / 692 ms — so #313 and this
PR together are −56% lexing and −31% parse.

The memory figure is the tokens of the whole corpus held at once: 605 MiB → 277
MiB. Three packed arrays cost 16 bytes per token per array; a packed array of
three zvals costs an array header plus a rounded-up slot allocation.

## Behaviour

Tokens and the ASTs printed from them are byte-identical to 2.3.5 over all
37 150 docblocks (xxh128 over both). On PHP 8.5, with the `make grammars-install`
toolchain in place so nothing is skipped: 7747 tests pass, including the grammar
sync and fuzzer suites, plus phpcs, PHPStan and the no-capturing-groups guard
test added in #313, which applies unchanged.

## Alternative I measured and discarded

`Token` objects instead of tuples, the other obvious way to shrink a token:
+21% lexing, +8% parse, 164 bytes/token. `new Token(...)` is a userland call
where the array literal is one opcode, and the ~2% the parser gains from reading
properties instead of indexing arrays does not pay for it. Same migration cost
as this PR, less than half the payoff — so if a token-representation break is
worth taking at all, this is the one to take.
