### PR TITLE
feat: add @param-closure-scope PHPDoc tag

### DIFF
--- a/src/Ast/PhpDoc/ParamClosureScopeTagValueNode.php
+++ b/src/Ast/PhpDoc/ParamClosureScopeTagValueNode.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDocParser\Ast\PhpDoc;
+
+use PHPStan\PhpDocParser\Ast\NodeAttributes;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use function trim;
+
+class ParamClosureScopeTagValueNode implements PhpDocTagValueNode
+{
+
+	use NodeAttributes;
+
+	public TypeNode $type;
+
+	public string $parameterName;
+
+	/** @var string (may be empty) */
+	public string $description;
+
+	public function __construct(TypeNode $type, string $parameterName, string $description)
+	{
+		$this->type = $type;
+		$this->parameterName = $parameterName;
+		$this->description = $description;
+	}
+
+	public function __toString(): string
+	{
+		return trim("{$this->type} {$this->parameterName} {$this->description}");
+	}
+
+	/**
+	 * @param array<string, mixed> $properties
+	 */
+	public static function __set_state(array $properties): self
+	{
+		$instance = new self($properties['type'], $properties['parameterName'], $properties['description']);
+		if (isset($properties['attributes'])) {
+			foreach ($properties['attributes'] as $key => $value) {
+				$instance->setAttribute($key, $value);
+			}
+		}
+		return $instance;
+	}
+
+}

--- a/src/Ast/PhpDoc/PhpDocNode.php
+++ b/src/Ast/PhpDoc/PhpDocNode.php
@@ -108,6 +108,17 @@ class PhpDocNode implements Node
 	}
 
 	/**
+	 * @return ParamClosureScopeTagValueNode[]
+	 */
+	public function getParamClosureScopeTagValues(string $tagName = '@param-closure-scope'): array
+	{
+		return array_filter(
+			array_column($this->getTagsByName($tagName), 'value'),
+			static fn (PhpDocTagValueNode $value): bool => $value instanceof ParamClosureScopeTagValueNode,
+		);
+	}
+
+	/**
 	 * @return PureUnlessCallableIsImpureTagValueNode[]
 	 */
 	public function getPureUnlessCallableIsImpureTagValues(string $tagName = '@pure-unless-callable-is-impure'): array

--- a/src/Parser/PhpDocParser.php
+++ b/src/Parser/PhpDocParser.php
@@ -357,6 +357,11 @@ class PhpDocParser
 					$tagValue = $this->parseParamClosureThisTagValue($tokens);
 					break;
 
+				case '@param-closure-scope':
+				case '@phpstan-param-closure-scope':
+					$tagValue = $this->parseParamClosureScopeTagValue($tokens);
+					break;
+
 				case '@pure-unless-callable-is-impure':
 				case '@phpstan-pure-unless-callable-is-impure':
 					$tagValue = $this->parsePureUnlessCallableIsImpureTagValue($tokens);
@@ -872,6 +877,15 @@ class PhpDocParser
 		$description = $this->parseOptionalDescription($tokens, false);
 
 		return new Ast\PhpDoc\ParamClosureThisTagValueNode($type, $parameterName, $description);
+	}
+
+	private function parseParamClosureScopeTagValue(TokenIterator $tokens): Ast\PhpDoc\ParamClosureScopeTagValueNode
+	{
+		$type = $this->typeParser->parse($tokens);
+		$parameterName = $this->parseRequiredVariableName($tokens);
+		$description = $this->parseOptionalDescription($tokens, false);
+
+		return new Ast\PhpDoc\ParamClosureScopeTagValueNode($type, $parameterName, $description);
 	}
 
 	private function parsePureUnlessCallableIsImpureTagValue(TokenIterator $tokens): Ast\PhpDoc\PureUnlessCallableIsImpureTagValueNode

--- a/src/Printer/Printer.php
+++ b/src/Printer/Printer.php
@@ -21,6 +21,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ImplementsTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueParameterNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MixinTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureScopeTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureThisTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamImmediatelyInvokedCallableTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamLaterInvokedCallableTagValueNode;
@@ -360,6 +361,9 @@ final class Printer
 			return trim("{$node->parameterName} {$node->description}");
 		}
 		if ($node instanceof ParamClosureThisTagValueNode) {
+			return trim("{$node->type} {$node->parameterName} {$node->description}");
+		}
+		if ($node instanceof ParamClosureScopeTagValueNode) {
 			return trim("{$node->type} {$node->parameterName} {$node->description}");
 		}
 		if ($node instanceof PureUnlessCallableIsImpureTagValueNode) {

--- a/tests/PHPStan/Parser/PhpDocParserTest.php
+++ b/tests/PHPStan/Parser/PhpDocParserTest.php
@@ -29,6 +29,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\InvalidTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueParameterNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MixinTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureScopeTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureThisTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamImmediatelyInvokedCallableTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamLaterInvokedCallableTagValueNode;
@@ -103,6 +104,7 @@ class PhpDocParserTest extends TestCase
 	 * @dataProvider provideParamLaterInvokedCallableTagsData
 	 * @dataProvider provideTypelessParamTagsData
 	 * @dataProvider provideParamClosureThisTagsData
+	 * @dataProvider provideParamClosureScopeTagsData
 	 * @dataProvider providePureUnlessCallableIsImpureTagsData
 	 * @dataProvider providePureUnlessParameterIsPassedTagsData
 	 * @dataProvider provideVarTagsData
@@ -724,6 +726,54 @@ class PhpDocParserTest extends TestCase
 				new PhpDocTagNode(
 					'@param-closure-this',
 					new ParamClosureThisTagValueNode(
+						new IdentifierTypeNode('Foo'),
+						'$a',
+						'test',
+					),
+				),
+			]),
+		];
+	}
+
+	public function provideParamClosureScopeTagsData(): Iterator
+	{
+		yield [
+			'OK',
+			'/** @param-closure-scope Foo $a */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@param-closure-scope',
+					new ParamClosureScopeTagValueNode(
+						new IdentifierTypeNode('Foo'),
+						'$a',
+						'',
+					),
+				),
+			]),
+		];
+
+		yield [
+			'OK with prefix',
+			'/** @phpstan-param-closure-scope Foo $a */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@phpstan-param-closure-scope',
+					new ParamClosureScopeTagValueNode(
+						new IdentifierTypeNode('Foo'),
+						'$a',
+						'',
+					),
+				),
+			]),
+		];
+
+		yield [
+			'OK with description',
+			'/** @param-closure-scope Foo $a test */',
+			new PhpDocNode([
+				new PhpDocTagNode(
+					'@param-closure-scope',
+					new ParamClosureScopeTagValueNode(
 						new IdentifierTypeNode('Foo'),
 						'$a',
 						'test',
@@ -7829,6 +7879,7 @@ Finder::findFiles('*.php')
 	 * @dataProvider provideParamImmediatelyInvokedCallableTagsData
 	 * @dataProvider provideParamLaterInvokedCallableTagsData
 	 * @dataProvider provideParamClosureThisTagsData
+	 * @dataProvider provideParamClosureScopeTagsData
 	 * @dataProvider provideVarTagsData
 	 * @dataProvider provideReturnTagsData
 	 * @dataProvider provideThrowsTagsData

--- a/tests/PHPStan/Printer/PrinterTest.php
+++ b/tests/PHPStan/Printer/PrinterTest.php
@@ -18,6 +18,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\Doctrine\DoctrineArgument;
 use PHPStan\PhpDocParser\Ast\PhpDoc\Doctrine\DoctrineArray;
 use PHPStan\PhpDocParser\Ast\PhpDoc\Doctrine\DoctrineArrayItem;
 use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureScopeTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamClosureThisTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamImmediatelyInvokedCallableTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamLaterInvokedCallableTagValueNode;
@@ -2134,6 +2135,25 @@ class PrinterTest extends TestCase
 				public function enterNode(Node $node)
 				{
 					if ($node instanceof ParamClosureThisTagValueNode) {
+						$node->type = new IdentifierTypeNode('Bar');
+						$node->parameterName = '$taste';
+						$node->description = 'hehe';
+					}
+
+					return $node;
+				}
+
+			},
+		];
+
+		yield [
+			'/** @param-closure-scope Foo $test haha */',
+			'/** @param-closure-scope Bar $taste hehe */',
+			new class extends AbstractNodeVisitor {
+
+				public function enterNode(Node $node)
+				{
+					if ($node instanceof ParamClosureScopeTagValueNode) {
 						$node->type = new IdentifierTypeNode('Bar');
 						$node->parameterName = '$taste';
 						$node->description = 'hehe';


### PR DESCRIPTION
Thanks!

Parse @param-closure-scope and @phpstan-param-closure-scope the same way as @param-closure-this, so callers can bind self/static independently of $this.

Thanks!